### PR TITLE
fix(grammar): keep TOC fixed

### DIFF
--- a/src/components/Grammar/index.scss
+++ b/src/components/Grammar/index.scss
@@ -114,7 +114,7 @@
     overflow-x: hidden;
 
     &__content {
-      position: absolute;
+      position: fixed;
       top: 70px;
       left: calc(50% - 515px);
       width: 235px;


### PR DESCRIPTION
Fixes regression - TOC should keep its position when scrolling the grammar contents:

![image](https://user-images.githubusercontent.com/1962469/117425074-1ffc1200-af2b-11eb-88ad-881fa774d19c.png)
