### PR TITLE
fix on grammar page (mužam->mužami)

### DIFF
--- a/src/components/Grammar/tables.json
+++ b/src/components/Grammar/tables.json
@@ -220,8 +220,8 @@
       "I@d;bb",
       "muž-{e}[g]m@br;r",
       "nož-{e}[g]m@bl;r",
-      "muž-{a}[r]m@br;bt;R",
-      "nož-{a}[r]m@bl;bt;R",
+      "muž-{a}[r]m{i}[b]@br;bt;R",
+      "nož-{a}[r]m{i}[b]@bl;bt;R",
       "muž-{a}[r]m{a}[r]@br;bt;r",
       "nož-{a}[r]m{a}[r]@bl;bt;r"
     ],


### PR DESCRIPTION
This is a small correction to the grammar page at the suggestion of the author of this video: https://www.youtube.com/watch?v=vA3LvVJ1rUA

![image](https://user-images.githubusercontent.com/56205890/136070211-b8bac28c-05c0-4700-b30b-c355dde42dc6.png)
