### PR TITLE
docs(grammar): fix spelling

### DIFF
--- a/src/components/Pages/Grammar/Grammar.tsx
+++ b/src/components/Pages/Grammar/Grammar.tsx
@@ -10,15 +10,15 @@ import tables from './tables.json';
 
 const titles = {
     abeceda: 'Abeceda',
-    imeniky: 'Imeniky',
-    zaimeniky: 'Zaimeniky',
+    imeniky: 'Imenniky',
+    zaimeniky: 'Zaimenniky',
     pridavniky: 'Pridavniky',
     glagoly: 'Glagoly',
     byti: 'Neredne glagoly',
     prislovniky: 'Prislovniky',
     predlogy: 'Prědlogy',
-    ciselniky: 'Čiselniky',
-    sovezniky: 'Sovezniky',
+    ciselniky: 'Čislovniky',
+    sovezniky: 'Svezniky',
     cestice: 'Čestice',
     medzuslovniky: 'Medžuslovniky',
     podredne: 'Podredne izrěčenja',
@@ -70,8 +70,8 @@ export default class Grammar extends PureComponent {
                                 {Napriměr:}[i] {r{y}[b]ba→r{i}[b]ba}[B], {r{ě}[g]ka→r{e}[g]ka}[B]`}
                         </Text>
                         <Text>
-                            {`Palatizacija i eufonija: {{k}[k]→{č}[k], {h}[k]→{š}[k], {g}[k]→{ž}[k], {c}[k]{j}[p]→{č}[k], {s}[k]{j}[p]→{š}[k], {zj}[k]→{ž}[k]}[B]
-                                {Napriměr:}[i] {Grě{k}[k]→grě{č}[k]sky}[B], {pra{h}[k]→pra{š}[k]ny}[B], {Bo{g}[k]→bo{ž}[k]sky}[B], {pro{s}[k]{ju}[p]→pro{š}[k]{u}[p]}[B]`}
+                            {`Palatalizacija i evfonija: {{k}[k]→{č}[k], {h}[k]→{š}[k], {g}[k]→{ž}[k], {c}[k]{j}[p]→{č}[k], {s}[k]{j}[p]→{š}[k], {zj}[k]→{ž}[k]}[B]
+                                {Napriměr:}[i] {Gre{k}[k]→gre{č}[k]sky}[B], {pra{h}[k]→pra{š}[k]ny}[B], {Bo{g}[k]→bo{ž}[k]sky}[B], {pro{s}[k]{ju}[p]→pro{š}[k]{u}[p]}[B]`}
                         </Text>
                         <Text indent="0.5rem">
                             {`{1.}[B,m] Staroslovjansko jatj={ѣ}[g,B]={ě}[g,B] se može pisati bez diakritiky kako {ie}[g,B] ili prosto {e}[g,B]. Podobno {č}[k,B], {š}[k,B], {ž}[k,B] se mogut pisati kako {cz}[k,B], {sz}[k,B], {zs}[k,B].`}
@@ -90,13 +90,13 @@ export default class Grammar extends PureComponent {
                         <Table data={tables.tableBrat} />
                         <Table data={tables.tableMuz} />
                         <Text>
-                            {`Mužske objekty, ktore aktivno dělajut někaky proces, sut {životne}[i] (od pytanja KTO?) i po tutoj pričině imajut akuzativ ravny s genitivom.`}
+                            {`Mužske objekty, ktore aktivno dělajut někaky proces, sut {žive}[i] (od pytanja KTO?) i po tutoj pričině imajut akuzativ ravny s genitivom.`}
                         </Text>
                         <Text>
-                            {`Ostalne objekty sut {neživotne}[i] (od pytanija ČTO) i imajut v jednině akuzativ ravny s nominativom.
+                            {`Ostale objekty sut {nežive}[i] (od pytanja ČTO) i imajut v jednině akuzativ ravny s nominativom.
                             {Napriměr:}[i]
-                               - {gospod peče {hlěb}[k].}[B] ({hlěb}[k,B] ne može pečti = jest neživotny)
-                               - {gospod vidi {člověka}[k]}[B]. ({člověk}[k,B] može viděti = jest životny)`}
+                               - {gospod peče {hlěb}[k].}[B] ({hlěb}[k,B] ne može pekti sebe = jest neživy)
+                               - {gospod vidi {člověka}[k]}[B]. ({člověk}[k,B] može viděti = jest živy)`}
                         </Text>
                         <Text>
                             {`Slova mužskogo roda zakončeni na -{a}[r,B] imajut v jednině klonjenje po tvrdom vzoru {žena}[k,B] ili mekkom vzoru {duša}[k,B], ale v množině i dvojině imajut normalny mužsky vzor.
@@ -107,10 +107,10 @@ export default class Grammar extends PureComponent {
                         <Table data={tables.tableZena} />
                         <Table data={tables.tableKost} />
                         <Text>
-                            {`Vse čiselniky zakončene na soglasniky –{T}[B] i –{Č}[B] ({PET}[B], {ŠEST}[B], ... {DESET}[B], {TRINADSET}[B], ... {DVADESET}[B], {TYSEČ}[B]) imajut klonjenje kako {KOST}[B] v jednině: {šest, šest-{i}[b], šest-j{u}[p]}[B] ...`}
+                            {`Vse čislovniky zakončene na soglasky –{T}[B] i –{Č}[B] ({PET}[B], {ŠEST}[B], ... {DESET}[B], {TRINADSET}[B], ... {DVADESET}[B], {TYSEČ}[B]) imajut klonjenje kako {KOST}[B] v jednině: {šest, šest-{i}[b], šest-j{u}[p]}[B] ...`}
                         </Text>
                         <Text>
-                            {`Dualne slova {OKO}[B], {UHO}[B] imajut dual ravne s množinoju vzora {KOST}[B] s palatizovanym korenom: {oč-{i}[b], oč-{ij}[b], oč-{a}[r]m}[B] ... {uš-{i}[b], uš-{i}[b]j, uš-{a}[r]m}[B] ... where {čj,šj,žj → č,š,ž}[B].`}
+                            {`Dvojinne slova {OKO}[B], {UHO}[B] imajut dvojinu ravnu s množinoju vzora {KOST}[B] s palatalizovanym korenem: {oč-{i}[b], oč-{ij}[b], oč-{a}[r]m}[B] ... {uš-{i}[b], uš-{i}[b]j, uš-{a}[r]m}[B] ... kde {čj,šj,žj → č,š,ž}[B].`}
                         </Text>
                         <Table data={tables.tableSelo} />
                         <Table data={tables.tableDen} />
@@ -128,7 +128,7 @@ export default class Grammar extends PureComponent {
                         <Table data={tables.tableTojTaTo} />
                         <Table data={tables.tableOnOnaOno} />
                         <Text>
-                            {`Mekky	vzor klonjenja {(-{e}[g]g{o}[p], -{e}[g]m{u}[p], ...)}[B] imajut zaimeniky:
+                            {`Mekky	vzor klonjenja {(-{e}[g]g{o}[p], -{e}[g]m{u}[p], ...)}[B] imajut zaimenniky:
                             - {MOJ-MOJA-MOJE, TVOJ-TVOJA-TVOJE, NAŠ-NAŠA-NAŠE, VAŠ-VAŠA-VAŠE, VSEj-VSA-VSE, KOJ, KOJA, KOJE, ČIJ, ČIJA, ČIJE ...}[B]`}
                         </Text>
                         <Text>
@@ -142,30 +142,30 @@ export default class Grammar extends PureComponent {
                         <br/>
                         <Table data={tables.tableGradacija} />
                         <Text>
-                            {`{kračenje: tvrd-{ěj}[s]-ši→tvrd-ši krat-{čej}[s]-ši→krat-ši bogat-{ěj}[s]-ši→bogat-ši}[B]`}
+                            {`{skračenje: tvrd-{ěj}[s]-ši→tvrd-ši krat-{čej}[s]-ši→krat-ši bogat-{ěj}[s]-ši→bogat-ši}[B]`}
                         </Text>
                     </Card>
                     <Card title={titles.glagoly} id="glagoly">
                         <Table data={tables.tableImeti} />
                         <Text>
-                            {`Pasivny prošly participij tvrdyh glagolov {–{i}[b]ti –{e}[g]ti –{u}[p]ti –yti}[B] jest {–{i}[b]ty –{e}[g]ty –{u}[p]ty –{y}[b]ty:}[B]
+                            {`Pasivny prošly particip tvrdyh glagolov {–{i}[b]ti –{e}[g]ti –{u}[p]ti –yti}[B] jest {–{i}[b]ty –{e}[g]ty –{u}[p]ty –{y}[b]ty:}[B]
                             {piti→pity, kleti→klety, obuti→obuty, kryti→kryty}[B] ...	vse	druge imajut {–▪ny}[B].`}
                         </Text>
                         <Table data={tables.tableVariti} />
                         <Text>
-                            {`Pasivny	prošly	participij	mekkyh	glagolov jest {–j{e}[g]ni –j{e}[g]na –j{e}[g]no}[B],
+                            {`Pasivny	prošly	particip	mekkyh	glagolov jest {–j{e}[g]ni –j{e}[g]na –j{e}[g]no}[B],
                             ale {dj→dž (viděti, vidžu, vidiš, vidženy),
                             tj→č (vratiti, vraču, vratiš, vračeny)
                             sj→š (prositi, prošu, prosiš, prošeny),
                             stj→šč (koristiti, korišču, koristiš, koriščeny)}[B]`}
                         </Text>
                         <Text>
-                            {`Pasivny prošly participij	vsih ostalnyh glagolov {–{a}[r]ti –{ě}[g]ti –▪ti jest –{a}[r]ny –{ě}[g]ny –{e}[g]ny:
+                            {`Pasivny prošly particip	vsih ostalyh glagolov {–{a}[r]ti –{ě}[g]ti –▪ti jest –{a}[r]ny –{ě}[g]ny –{e}[g]ny:
                             dělati→dělany, pekti→pek–eny→pečeny ...}[B]`}
                         </Text>
                         <Table data={tables.tableVremena} />
                         <Text>
-                            {`Aktivne glagolne participija možut tvoriti aktivny sučny i aktivny prošly prislovniky:
+                            {`Aktivne glagolne participy mogut tvoriti aktivny suči i aktivny prošly prislovniky:
                             {dělati → {dělaj}[k]-{u}[p]-č, děl-{a}[r]-v
                              variti → var-{e}[g]-č, var-{i}[b]-v}[B]`}
                         </Text>
@@ -186,7 +186,7 @@ export default class Grammar extends PureComponent {
                     </Card>
                     <Card title={titles.prislovniky} id="prislovniky">
                         <Text>
-                            {`Poslě tvrdyh soglasnikov jest zakončenje {-{o}[p]}[B], poslě mekkyh {č š ž j}[B,k] jest {-{e}[g]}[B].
+                            {`Poslě tvrdyh soglasok jest zakončenje {-{o}[p]}[B], poslě mekkyh {č š ž j}[B,k] jest {-{e}[g]}[B].
                             {Napriměr:}[i] {dobr-{o}[p]}[B], {bystr-{o}[p]}[B], {už-{e}[g]}[B], {daž-{e}[g]}[B], {menš-{e}[g]}[B]`}
                         </Text>
                         <Text>
@@ -211,7 +211,7 @@ export default class Grammar extends PureComponent {
                             jedin, jednogo (TOJ)
                             {pet, peti... 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 (KOST)}[g]
                             {nula, nuly (ŽENA)}[p]
-                            {sto, sta (SĚLO)}[b]
+                            {sto, sta (SELO)}[b]
                             {tyseč, tyseči (KOST)}[g]
                             milion, miliona (GRAD)}[B]`}
                         </Text>
@@ -225,13 +225,13 @@ export default class Grammar extends PureComponent {
                     <Card title={titles.medzuslovniky} id="medzuslovniky">
                         <Text>
                             {`{oh! ah! uva! lutě!}[B]
-                            «značenje medžuslovnika takože imajut vse izrěčenja v navodnikah»`}
+                            «značenje medžuslovnika takože imajut vse izrěčenja v navodnicah»`}
                         </Text>
                     </Card>
                     <Card title={titles.podredne} id="podredne">
                         <Text>
                             {`{..., kde ... ..., ktoromu..., tako ..., kako ... toliko ..., koliko ... ..., že ...}[B]
-                            tvary {iže, jegože, jimže}[B], ... sut relativne zaimeniky od on, ona, ono `}
+                            tvary {iže, jegože, jimže}[B], ... sut relativne zaimenniky od on, ona, ono `}
                         </Text>
                     </Card>
                     {/*<Card title={titles.naucno} id="naucno">*/}
@@ -249,12 +249,12 @@ export default class Grammar extends PureComponent {
                             {`1. Dvojina je shranila se nyně jedino v slovenskom i lužičskyh jezykah, tomu vměsto tutoj formy jest rekomendovano koristati množinu.`}
                         </Text>
                         <Text>
-                            {`2. Prosto prošlo vrěme (aorist, imperfect) je shranilo se jedino v česti slovjanskyh jezykov, tomu vměsto njego jest rekomendovano koristati glagol byti + l-participij (pisah → jesm pisal).`}
+                            {`2. Prosto prošlo vrěme (aorist, imperfect) je shranilo se jedino v česti slovjanskyh jezykov, tomu vměsto njego jest rekomendovano koristati glagol byti + l-particip (pisah → jesm pisal).`}
                         </Text>
                     </Card>
                     <Card title={titles.podrobnosti} id="podrobnosti">
                         <Text>
-                            {`Pri sozdanji tutoj stranicy jest upotrěbjeny dokument «Medžuslovjansky jezyk. Abeceda i pravopisanie» (Januar 2018): <a href="http://interslavic-language.org/doc/ns-pregled.pdf" target="_blank">[PDF]</a>`}
+                            {`Pri stvorjenju tutoj stranice jest upotrěbjeny dokument «Medžuslovjansky jezyk. Abeceda i pravopisanie» (Januar 2018): <a href="http://interslavic-language.org/doc/ns-pregled.pdf" target="_blank">[PDF]</a>`}
                         </Text>
                         <Text>
                             {`Podrobne pravila pravopisanja je možno najdti na oficialnyh sajtah:`}

--- a/src/components/Pages/Grammar/Grammar.tsx
+++ b/src/components/Pages/Grammar/Grammar.tsx
@@ -25,7 +25,7 @@ const titles = {
     // naucno: 'Naučno pravopisanje i kirilica',
     glagolica: 'Glagolica',
     primetky: 'Primětky (*)',
-    podrobnosti: 'Podrobne pravila (linki)',
+    podrobnosti: 'Podrobne pravila (linky)',
 };
 
 export default class Grammar extends PureComponent {

--- a/src/components/Pages/Grammar/Grammar.tsx
+++ b/src/components/Pages/Grammar/Grammar.tsx
@@ -165,7 +165,7 @@ export default class Grammar extends PureComponent {
                         </Text>
                         <Table data={tables.tableVremena} />
                         <Text>
-                            {`Aktivne glagolne participy mogut tvoriti aktivny suči i aktivny prošly prislovniky:
+                            {`Aktivne glagolne participy mogut tvoriti aktivny nastoječi i aktivny prošly prislovniky:
                             {dělati → {dělaj}[k]-{u}[p]-č, děl-{a}[r]-v
                              variti → var-{e}[g]-č, var-{i}[b]-v}[B]`}
                         </Text>

--- a/src/components/Pages/Grammar/tables.json
+++ b/src/components/Pages/Grammar/tables.json
@@ -353,7 +353,7 @@
       "L@d;bb",
       "kost-{i}[b]@bb;g",
       "deset-{i}[b]@bb;g",
-      "kost-{ja}[r]h@G",
+      "kost-{a}[r]h@G",
       "oč-{a}[r]h@G",
       "kost-{ju}[p]@bt;b"
     ],
@@ -361,17 +361,17 @@
       "D@d;bb",
       "kost-{i}[b]@bt;g",
       "deset-{i}[b]@bt;g",
-      "kost-{ja}[r]m@bb;R",
+      "kost-{a}[r]m@bb;R",
       "oč-{a}[r]m@bb;R",
-      "kost-{ja}[r]m{a}[r]@bb;r"
+      "kost-{a}[r]m{a}[r]@bb;r"
     ],
     [
       "I@d;bb",
       "kost-{ju}[p]@r",
       "deset-{ju}[p]@r",
-      "kost-{ja}[r]m{i}[b]@bt;R",
+      "kost-{a}[r]m{i}[b]@bt;R",
       "oč-{a}[r]m{i}[b]@bt;R",
-      "kost-{ja}[r]m{a}[r]@bt;r"
+      "kost-{a}[r]m{a}[r]@bt;r"
     ],
     [
       "V@d",

--- a/src/components/Pages/Grammar/tables.json
+++ b/src/components/Pages/Grammar/tables.json
@@ -1046,18 +1046,18 @@
       "im-{ě}[g]-ti@w=2;ts"
     ],
     [
-      "L-participij@d;w=2",
+      "L-particip@d;w=2",
       "im-{ě}[g]-l, im-{ě}[g]-la, im-{ě}[g]-lo, im-{ě}[g]-li, im-{ě}[g]-le@w=2;ts"
     ],
     [
       "glagolno ime@d;w=2",
-      "im-{ě}[g]-nje {(od prošlogo pasivnogo participija)}[s]@w=2;ts"
+      "im-{ě}[g]-nje {(od prošlogo pasivnogo participa)}[s]@w=2;ts"
     ],
     [
-      "sučo vrěme (tvrde glagoly možut iměti suči koren @w=4;D;bb;ts"
+      "nastoječe vrěme (tvrde glagoly možut iměti koren v nastoječem @w=4;D;bb;ts"
     ],
     [
-      "nerovny s korenom infinitiva)@w=4;D;bt;ts"
+      "vrěmeni, ktory ne sběgaje se s korenem infinitiva)@w=4;D;bt;ts"
     ],
     [
       "&nbsp@d",
@@ -1085,20 +1085,20 @@
     ],
     [
       "&nbsp@d;bb;br;w=2",
-      "aktivny suči participij@d;bb",
+      "aktivny nastoječi particip@d;bb",
       "{imaj}[k]-{u}[p]či {≈ jesmy}[s]@B"
     ],
     [
       "&nbsp@d;bt;br;w=2",
-      "pasivny suči participij@d;bt;te",
-      "{imaj}[k]-{e}[g]my {≈ suči}[s]@b"
+      "pasivny nastoječi particip@d;bt;te",
+      "{imaj}[k]-{e}[g]my {≈ nastoječi}[s]@b"
     ],
     [
       "imperativ@w=2;d",
       "{imaj}[k]{!}[s] {imaj}[k]-mo{!}[s] {imaj}[k]-te{!}[s]@w=2;r"
     ],
     [
-      "prosto prošlo vrěme<a href=\"#primetky\">*</a>@w=4;D;bb"
+      "imperfekt<a href=\"#primetky\">*</a>@w=4;D;bb"
     ],
     [
       "(infinitivny koren i samoglasnik iz infinitivnogo zakončenja)@w=4;D;bt"
@@ -1129,12 +1129,12 @@
     ],
     [
       "&nbsp@d;bb;w=2",
-      "aktivny prošly participij@d;bb",
+      "aktivny prošly particip@d;bb",
       "im-{ě}[g]-vši {≈ b-y-ty}[s]"
     ],
     [
       "&nbsp@d;bt;w=2",
-      "pasivny prošly participij@d;bt;te",
+      "pasivny prošly particip@d;bt;te",
       "im-{ě}[g]-ny {≈ b-y-vši}[s]@r"
     ]
   ],
@@ -1149,18 +1149,18 @@
       "var-{i}[b]-ti@w=2;ts"
     ],
     [
-      "L-participij@d;w=2",
+      "L-particip@d;w=2",
       "var-{i}[b]-l, var-{i}[b]-la, var-{i}[b]-lo, var-{i}[b]-li, var-{i}[b]-le@w=2;ts"
     ],
     [
       "glagolno ime@d;w=2",
-      "var-j{e}[g]-nje {(od prošlogo pasivnogo participija)}[s]@w=2;ts"
+      "var-j{e}[g]-nje {(od prošlogo pasivnogo participa)}[s]@w=2;ts"
     ],
     [
-      "sučo vrěme (tvrde glagoly možut iměti suči koren @w=4;D;bb"
+      "nastoječe vrěme (tvrde glagoly možut iměti koren v nastoječem @w=4;D;bb"
     ],
     [
-      "nerovny s korenom infinitiva)@w=4;D;bt"
+      "vrěmeni, ktory ne sběgaje se s korenem infinitiva)@w=4;D;bt"
     ],
     [
       "&nbsp@d",
@@ -1188,12 +1188,12 @@
     ],
     [
       "&nbsp@d;bb;br;w=2",
-      "aktivny suči participij@d;bb",
+      "aktivny nastoječi particip@d;bb",
       "var-{e}[g]či@B"
     ],
     [
       "&nbsp@d;bt;br;w=2",
-      "pasivny suči participij@d;bt;te",
+      "pasivny nastoječi particip@d;bt;te",
       "var-{i}[b]my@b"
     ],
     [
@@ -1201,7 +1201,7 @@
       "var-{i}[b]{!}[s] var-{i}[b]mo{!}[s] var-{i}[b]te{!}[s]@w=2;r"
     ],
     [
-      "prosto prošlo vrěme<a href=\"#primetky\">*</a> (infinitivny koren i samoglasnik iz infinitivnogo zakončenja)@w=4;D;bb;bt"
+      "imperfekt<a href=\"#primetky\">*</a> (infinitivny koren i samoglasnik iz infinitivnogo zakončenja)@w=4;D;bb;bt"
     ],
     [
       "&nbsp@d",
@@ -1229,12 +1229,12 @@
     ],
     [
       "&nbsp@d;bb;w=2",
-      "aktivny prošly participij@d;bb",
+      "aktivny prošly particip@d;bb",
       "var-{i}[b]-vši"
     ],
     [
       "&nbsp@d;bt;w=2",
-      "pasivny prošly participij@d;bt;te",
+      "pasivny prošly particip@d;bt;te",
       "var-j{e}[g]-ny@r"
     ]
   ],
@@ -1255,22 +1255,22 @@
       "budu napisal@R"
     ],
     [
-      "sučo vrěme@D",
+      "nastoječe vrěme@D",
       "pišu@b",
       "-@b"
     ],
     [
-      "prědsučo vrěme@d",
+      "perfekt@d",
       "jesm pisal@B",
       "jesm napisal@B"
     ],
     [
-      "prosto prošlo vrěme<a href=\"#primetky\">*</a>@D",
+      "imperfekt<a href=\"#primetky\">*</a>@D",
       "pisah@",
       "napisah@"
     ],
     [
-      "prědprošlo vrěme@d",
+      "pluskvamperfekt@d",
       "běh pisal@S",
       "běh napisal@S"
     ]
@@ -1285,12 +1285,12 @@
     "b-{y}[b]-ti@w=2;ts"
   ],
   [
-    "L-participij@d;w=2",
+    "L-particip@d;w=2",
     "b-{y}[b]-l, b-{y}[b]-la, b-{y}[b]-lo, b-{y}[b]-li, b-{y}[b]-le@w=2;ts"
   ],
   [
     "glagolno ime@d;w=2",
-    "b-{y}[b]-tje {(od prošlogo pasivnogo participija)}[s]@w=2;ts"
+    "b-{y}[b]-tje {(od prošlogo pasivnogo participa)}[s]@w=2;ts"
   ],
   [
     "buduče vrěme@w=4;D"
@@ -1321,20 +1321,20 @@
   ],
   [
     "&nbsp@d;bb;br;w=2",
-    "aktivny buduči participij@d;bb",
+    "aktivny buduči particip@d;bb",
     "{bud}[k]-{u}[p]či {≈ jesmy}[s]@B"
   ],
   [
     "&nbsp@d;bt;br;w=2",
-    "pasivny buduči participij@d;bt;te",
-    "{bud}[k]-{e}[g]my {≈ suči}[s]@b"
+    "pasivny buduči particip@d;bt;te",
+    "{bud}[k]-{e}[g]my {≈ nastoječi}[s]@b"
   ],
   [
     "imperativ@w=2;d",
     "{bud}[k]-{i}[b]{!}[s] {bud}[k]-{i}[b]mo{!}[s] {bud}[k]-{i}[b]te{!}[s]@w=2;r"
   ],
   [
-    "sučo vrěme@w=4;D"
+    "nastoječe vrěme@w=4;D"
   ],
   [
     "&nbsp@d",
@@ -1362,16 +1362,16 @@
   ],
   [
     "&nbsp@d;bb;br;w=2",
-    "aktivny suči participij@d;bb",
-    "{suči}[k] {≈ imaj-emy}[s]@B"
+    "aktivny nastoječi particip@d;bb",
+    "{nastoječi}[k] {≈ imaj-emy}[s]@B"
   ],
   [
     "&nbsp@d;bt;br;w=2",
-    "pasivny suči participij@d;bt;te",
+    "pasivny nastoječi particip@d;bt;te",
     "{jesmy}[k] {≈ imaj-uči}[s]@b"
   ],
   [
-    "prosto prošlo vrěme<a href=\"#primetky\">*</a>@w=4;D"
+    "imperfekt<a href=\"#primetky\">*</a>@w=4;D"
   ],
   [
     "&nbsp@d",
@@ -1399,12 +1399,12 @@
   ],
   [
     "&nbsp@d;bb;w=2",
-    "aktivny prošly participij@d;bb",
+    "aktivny prošly particip@d;bb",
     "by-{y}[b]-vši {≈ im-ě-ny}[s]"
   ],
   [
     "&nbsp@d;bt;w=2",
-    "pasivny prošly participij@d;bt;te",
+    "pasivny prošly particip@d;bt;te",
     "b-{y}[b]-ty {≈ im-ě-vši}[s]@r"
   ],
     [

--- a/src/components/Pages/Grammar/tables.json
+++ b/src/components/Pages/Grammar/tables.json
@@ -1569,7 +1569,7 @@
       "20@d",
       "{dvadeset}[g]",
       "200@d",
-      "{dvěsto}[b]",
+      "{dvasto}[b]",
       "2000@d",
       "dva {tyseč}[g]"
     ],
@@ -1662,7 +1662,7 @@
       "30@d",
       "tridesety",
       "201@d",
-      "dvěsto prvy"
+      "dvasto prvy"
     ],
     [
       "4@d",
@@ -1670,7 +1670,7 @@
       "40@d",
       "četyridesety",
       "210@d",
-      "dvěsto desety"
+      "dvasto desety"
     ],
     [
       "5@d",

--- a/src/components/Pages/Grammar/tables.json
+++ b/src/components/Pages/Grammar/tables.json
@@ -1054,7 +1054,7 @@
       "im-{ě}[g]-nje {(od prošlogo pasivnogo participija)}[s]@w=2;ts"
     ],
     [
-      "sučno vrěme (tvrde glagoly možut iměti sučny koren @w=4;D;bb;ts"
+      "sučo vrěme (tvrde glagoly možut iměti suči koren @w=4;D;bb;ts"
     ],
     [
       "nerovny s korenom infinitiva)@w=4;D;bt;ts"
@@ -1085,13 +1085,13 @@
     ],
     [
       "&nbsp@d;bb;br;w=2",
-      "aktivny sučny participij@d;bb",
+      "aktivny suči participij@d;bb",
       "{imaj}[k]-{u}[p]či {≈ jesmy}[s]@B"
     ],
     [
       "&nbsp@d;bt;br;w=2",
-      "pasivny sučny participij@d;bt;te",
-      "{imaj}[k]-{e}[g]my {≈ sučny}[s]@b"
+      "pasivny suči participij@d;bt;te",
+      "{imaj}[k]-{e}[g]my {≈ suči}[s]@b"
     ],
     [
       "imperativ@w=2;d",
@@ -1157,7 +1157,7 @@
       "var-j{e}[g]-nje {(od prošlogo pasivnogo participija)}[s]@w=2;ts"
     ],
     [
-      "sučno vrěme (tvrde glagoly možut iměti sučny koren @w=4;D;bb"
+      "sučo vrěme (tvrde glagoly možut iměti suči koren @w=4;D;bb"
     ],
     [
       "nerovny s korenom infinitiva)@w=4;D;bt"
@@ -1188,12 +1188,12 @@
     ],
     [
       "&nbsp@d;bb;br;w=2",
-      "aktivny sučny participij@d;bb",
+      "aktivny suči participij@d;bb",
       "var-{e}[g]či@B"
     ],
     [
       "&nbsp@d;bt;br;w=2",
-      "pasivny sučny participij@d;bt;te",
+      "pasivny suči participij@d;bt;te",
       "var-{i}[b]my@b"
     ],
     [
@@ -1255,12 +1255,12 @@
       "budu napisal@R"
     ],
     [
-      "sučno vrěme@D",
+      "sučo vrěme@D",
       "pišu@b",
       "-@b"
     ],
     [
-      "prědsučno vrěme@d",
+      "prědsučo vrěme@d",
       "jesm pisal@B",
       "jesm napisal@B"
     ],
@@ -1327,14 +1327,14 @@
   [
     "&nbsp@d;bt;br;w=2",
     "pasivny buduči participij@d;bt;te",
-    "{bud}[k]-{e}[g]my {≈ sučny}[s]@b"
+    "{bud}[k]-{e}[g]my {≈ suči}[s]@b"
   ],
   [
     "imperativ@w=2;d",
     "{bud}[k]-{i}[b]{!}[s] {bud}[k]-{i}[b]mo{!}[s] {bud}[k]-{i}[b]te{!}[s]@w=2;r"
   ],
   [
-    "sučno vrěme@w=4;D"
+    "sučo vrěme@w=4;D"
   ],
   [
     "&nbsp@d",
@@ -1362,12 +1362,12 @@
   ],
   [
     "&nbsp@d;bb;br;w=2",
-    "aktivny sučny participij@d;bb",
-    "{sučny}[k] {≈ imaj-emy}[s]@B"
+    "aktivny suči participij@d;bb",
+    "{suči}[k] {≈ imaj-emy}[s]@B"
   ],
   [
     "&nbsp@d;bt;br;w=2",
-    "pasivny sučny participij@d;bt;te",
+    "pasivny suči participij@d;bt;te",
     "{jesmy}[k] {≈ imaj-uči}[s]@b"
   ],
   [

--- a/src/components/Pages/Grammar/tables.json
+++ b/src/components/Pages/Grammar/tables.json
@@ -1054,10 +1054,10 @@
       "im-{ě}[g]-nje {(od prošlogo pasivnogo participa)}[s]@w=2;ts"
     ],
     [
-      "nastoječe vrěme (tvrde glagoly možut iměti koren v nastoječem @w=4;D;bb;ts"
+      "nastoječe vrěme (tvrde glagoly mogut iměti koren v nastoječem @w=4;D;bb;ts"
     ],
     [
-      "vrěmeni, ktory ne sběgaje se s korenem infinitiva)@w=4;D;bt;ts"
+      "vrěmeni, ne jednaky s korenem infinitiva)@w=4;D;bt;ts"
     ],
     [
       "&nbsp@d",

--- a/src/components/Pages/Grammar/tables.json
+++ b/src/components/Pages/Grammar/tables.json
@@ -385,7 +385,7 @@
   "tableSelo": [
     [
       "&nbsp@bt;bl;br;bb",
-      "SĚLO@bt;bl;br",
+      "SELO@bt;bl;br",
       "POLJE@bt;bl;br",
       "&nbsp@bt;bl;br",
       "srědne tvrdy i mekky vzory@bt;bl;br;w=3;te"
@@ -398,65 +398,65 @@
     ],
     [
       "N@d;bb",
-      "sěl-{o}[p]@bb",
+      "sel-{o}[p]@bb",
       "polj-{e}[g]@bb",
-      "sěl-{a}[r]@bb;s",
+      "sel-{a}[r]@bb;s",
       "polj-{a}[r]@bb;s",
-      "sěl-{ě}[g]@bb",
+      "sel-{ě}[g]@bb",
       "polj-{i}[b]@bb"
     ],
     [
       "A@d;bb",
-      "sěl-{o}[p]@bt",
+      "sel-{o}[p]@bt",
       "polj-{e}[g]@bt",
-      "sěl-{a}[r]@bt;s",
+      "sel-{a}[r]@bt;s",
       "polj-{a}[r]@bt;s",
-      "sěl-{ě}[g]@bt",
+      "sel-{ě}[g]@bt",
       "polj-{i}[b]@bt"
     ],
     [
       "G@d;bb",
-      "sěl-{a}[r]@b",
+      "sel-{a}[r]@b",
       "polj-{a}[r]@b",
-      "sěl@B",
+      "sel@B",
       "polj{(-}[s]{e}[g]j{)}[s]@B",
-      "sěl-{u}[p]@bb;b",
+      "sel-{u}[p]@bb;b",
       "polj-{u}[p]@bb;b"
     ],
     [
       "L@d;bb",
-      "sěl-{u}[p]@bb;g",
+      "sel-{u}[p]@bb;g",
       "polj-{u}[p]@bb;g",
-      "sěl-{a}[r]h@G",
+      "sel-{a}[r]h@G",
       "polj-{a}[r]h@G",
-      "sěl-{u}[p]@bt;b",
+      "sel-{u}[p]@bt;b",
       "polj-{u}[p]@bt;b"
     ],
     [
       "D@d;bb",
-      "sěl-{u}[p]@bt;g",
+      "sel-{u}[p]@bt;g",
       "polj-{u}[p]@bt;g",
-      "sěl-{a}[r]m@bb;R",
+      "sel-{a}[r]m@bb;R",
       "polj-{a}[r]m@bb;R",
-      "sěl-{a}[r]m{a}[r]@bb;r",
+      "sel-{a}[r]m{a}[r]@bb;r",
       "polj-{a}[r]m{a}[r]@bb;r"
     ],
     [
       "I@d;bb",
-      "sěl-{o}[p]m@r",
+      "sel-{o}[p]m@r",
       "polj-{e}[g]m@r",
-      "sěl-{a}[r]m{i}[b]@bt;R",
+      "sel-{a}[r]m{i}[b]@bt;R",
       "polj-{a}[r]m{i}[b]@bt;R",
-      "sěl-{a}[r]m{a}[r]@bt;r",
+      "sel-{a}[r]m{a}[r]@bt;r",
       "polj-{a}[r]m{a}[r]@bt;r"
     ],
     [
       "V@d",
-      "sěl-{o}[p]{!}[s]@s",
+      "sel-{o}[p]{!}[s]@s",
       "polj-{e}[g]{!}[s]@s",
-      "sěl-{a}[r]{!}[s]@S",
+      "sel-{a}[r]{!}[s]@S",
       "polj-{a}[r]{!}[s]@S",
-      "sěl-{ě}[g]{!}[s]@s",
+      "sel-{ě}[g]{!}[s]@s",
       "polj-{i}[b]{!}[s]@s"
     ]
   ],


### PR DESCRIPTION
1) fixes kost' declensions according to the discussion in Interslavic DEV chat
2) in tables.json, replaces sučny - nastoječi , sučno - nastoječe, participij - particip (to ensure people can find the translation of this word) 
3) fixes spelling inconsistencies with the current Interslavic dictionary on Grammar page:
    1. palatizacija - palatalizacija
    2. grěk - grek, grěčsky - grečsky
    4. eufonija - evfonija (ὐ -> v, odnosno tutdennogo MS)
    5. imeniky - imenniky
    6. ostalne - ostale
    7. pytanija - pytanja
    8. neživotne - nežive
    9. životne - žive
    10. pečti - pekti sebe 
    12. čiselniky - čislovniky
    13. soglasniky - soglasky
    14. dualne - dvojinne, dual - dvojina
    15. palatizovanym - palatalizovanym
    16. korenom - korenem
    17. where - kde
    18. zaimeniky - zaimenniky
    21. participij - particip
    23. samoglasnik - samoglaska
    24. možut - mogut
    25. dvěsto - dvasto 
    26. SĚLO - SELO
    27. Sovezniky - Svezniky
    28. navodnikah - navodnicah
    29. sozdanji - stvorjenju 
    30. stranicy - stranice