### PR TITLE
fix: search beta words by id

### DIFF
--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -322,7 +322,7 @@ class DictionaryClass {
 
         if (inputText.slice(0, 2) === 'id') {
             const id = inputText.slice(2);
-            const idIsInt = /^\d+$/.test(id);
+            const idIsInt = /^-?\d+$/.test(id);
 
             if (idIsInt) {
                 const word = this.getWord(id);


### PR DESCRIPTION
Fixes problem with sharing words with negative IDs (beta words from the community):

![image](https://user-images.githubusercontent.com/1962469/226860437-07a374a7-3c78-4348-803a-90b288a1badf.png)
