### PR TITLE
Add OpenSearch description

### DIFF
--- a/src/index.html.ejs
+++ b/src/index.html.ejs
@@ -48,6 +48,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="icons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">
   <link rel="icon" type="image/png" sizes="16x16" href="icons/favicon-16x16.png">
+  <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Interslavic Dictionary">
   <title>Interslavic Dictionary</title>
   <meta name="Description"
         content="It is a dictionary of the Interslavic language with translations into most of the Slavic languages, as well as into English, German and others. The project is being developed by a community of fans of this zonal constructed language.">

--- a/static/opensearch.xml
+++ b/static/opensearch.xml
@@ -1,0 +1,8 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+    <ShortName>Interslavic Dictionary</ShortName>
+    <Description>Search Interslavic Dictionary</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16" type="image/png">https://interslavic-dictionary.com/icons/favicon-16x16.png</Image>
+    <Url type="text/html" method="get" template="https://interslavic-dictionary.com/?text={searchTerms}&amp;ref=opensearch"/>
+    <moz:SearchForm>https://interslavic-dictionary.com/</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
This will allow to easily add interslavic-dictionary.com as a default search in Firefox and maybe some other browsers.

See spec at https://developer.mozilla.org/en-US/docs/Web/OpenSearch

Tried to follow github.com's example. Didn't test how correct it is. `&ref=opensearch` can probably be removed.