### PR TITLE
Removed unused column column 'intelligibility' from page 'Wordlist'

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -53,7 +53,7 @@ export const initialFields = [
     'en',
     'sameInLanguages',
     'genesis',
-    'intelligibility',
+    //'intelligibility',
 ];
 
 export const initialAddFields = [


### PR DESCRIPTION
Tako jest dnes:
![image](https://github.com/sonic16x/interslavic/assets/56205890/7044409b-4a68-489e-9ba0-5306d5ceb7ed)
Tako bude:
![image](https://github.com/sonic16x/interslavic/assets/56205890/a4411386-9add-434b-bbb4-ecbaf1eab2a2)
