### PR TITLE
refactor: smart transliteration in translate

### DIFF
--- a/src/translations/translations.ts
+++ b/src/translations/translations.ts
@@ -1,10 +1,16 @@
 import translations from 'translations/data.json';
 
+import { createTaggedTemplate } from "utils/createTaggedTemplate";
 import { getCyrillic } from 'utils/getCyrillic';
 import { getGlagolitic } from 'utils/getGlagolitic';
 import { getLatin } from 'utils/getLatin';
+import { parseI18nString } from "utils/parseI18nString";
 
 let currentLang;
+
+const toLatin = createTaggedTemplate((s) => getLatin(String(s), '3'), 'strings');
+const toCyrillic = createTaggedTemplate((s) => getCyrillic(String(s), '3'), 'strings');
+const toGlagolitic = createTaggedTemplate((s) => getGlagolitic(String(s), '3'), 'strings');
 
 interface ITranslateParams {
     [key: string]: string;
@@ -22,23 +28,16 @@ function tRaw(key) {
         return key;
     } else if (translations[key][lang]) {
         if (lang === 'isv') {
-            // preserving substitutions in brackets {} from transliteration
-            let isvText = '', isvSubst = [], i = 0;
-            isvText = translations[key].isv.replace(/\{.*?\}/g,(match) => { 
-                isvSubst[i++] = match.slice(1,-1); 
-                return `{${i}}`;
-            });
-            // transliteration & flavorisation of isv word 
+            const parsed = parseI18nString(translations[key].isv);
+            // transliteration & flavorisation of isv word
             switch (alphabet) {
                 case 'Latn':
-                    isvText = getLatin(isvText, '3'); break;
+                    return toLatin(...parsed);
                 case 'Cyrl':
-                    isvText = getCyrillic(isvText, '3'); break;
+                    return toCyrillic(...parsed);
                 case 'Glag':
-                    isvText = getGlagolitic(isvText, '3'); break;
+                    return toGlagolitic(...parsed);
             }
-            // restoring substitutions in brackets
-            return isvText.replace(/\{\d+\}/g, (match) => isvSubst[parseInt(match.slice(1,-1))-1]);
         } else {
             return translations[key][lang];
         }

--- a/src/utils/createTaggedTemplate/createTaggedTemplate.test.ts
+++ b/src/utils/createTaggedTemplate/createTaggedTemplate.test.ts
@@ -1,0 +1,37 @@
+import { getCyrillic } from '../getCyrillic';
+
+import { createTaggedTemplate } from './createTaggedTemplate';
+
+describe('createTaggedTemplate', () => {
+    const toCyrillic = (s: unknown) => getCyrillic(String(s), '3');
+
+    test('applies transformation to template strings', () => {
+        const Cyrl = createTaggedTemplate(toCyrillic, 'strings');
+        const result = Cyrl`Pozdrav, ${'world'}! Kako ${'you'} jesi?`;
+        expect(result).toBe('Поздрав, world! Како you јеси?');
+    });
+
+    test('applies transformation to interpolated values', () => {
+        const Cyrl = createTaggedTemplate(toCyrillic, 'values');
+        const result = Cyrl`Hello, ${'Světe'}! How are ${'ty'}?`;
+        expect(result).toBe('Hello, Свєте! How are ты?');
+    });
+
+    test('handles empty template strings', () => {
+        const Cyrl = createTaggedTemplate(toCyrillic, 'strings');
+        const result = Cyrl``;
+        expect(result).toBe('');
+    });
+
+    test('handles template strings without interpolated values', () => {
+        const Cyrl = createTaggedTemplate(toCyrillic, 'strings');
+        const result = Cyrl`Pozdrav, světe!`;
+        expect(result).toBe('Поздрав, свєте!');
+    });
+
+    test('handles interpolated values of different types', () => {
+        const Cyrl = createTaggedTemplate(toCyrillic, 'values');
+        const result = Cyrl`Value 1: ${123}, Value 2: ${true}, Value 3: ${null}, Value 4: ${undefined}`;
+        expect(result).toBe('Value 1: 123, Value 2: труе, Value 3: нулл, Value 4: ундефинед');
+    });
+});

--- a/src/utils/createTaggedTemplate/createTaggedTemplate.ts
+++ b/src/utils/createTaggedTemplate/createTaggedTemplate.ts
@@ -1,0 +1,20 @@
+/**
+ * Creates a tagged template literal function that applies a transformation to either the template strings or the interpolated values.
+ *
+ * @param {(s: string) => string} transformFn - The function to apply to each string or value.
+ * @param {'strings' | 'values'} applyTo - Specifies whether to apply the transformation to the template strings or the interpolated values.
+ * @returns {(strings: TemplateStringsArray, ...values: unknown[]) => string} The tagged template literal function.
+ */
+export function createTaggedTemplate(
+    transformFn: (value: unknown) => string,
+    applyTo: 'strings' | 'values'
+): (strings: TemplateStringsArray, ...values: unknown[]) => string {
+    return (strings: TemplateStringsArray, ...values: unknown[]): string => {
+        const $strings = applyTo === 'strings' ? strings.map(transformFn) : strings;
+        const $values = applyTo === 'values' ? values.map(transformFn) : values;
+
+        return $strings.reduce((result, str, index) => {
+            return result + str + ($values[index] || '');
+        }, '');
+    };
+}

--- a/src/utils/createTaggedTemplate/index.ts
+++ b/src/utils/createTaggedTemplate/index.ts
@@ -1,0 +1,1 @@
+export * from './createTaggedTemplate';

--- a/src/utils/parseI18nString/index.ts
+++ b/src/utils/parseI18nString/index.ts
@@ -1,0 +1,1 @@
+export * from './parseI18nString';

--- a/src/utils/parseI18nString/parseI18nString.test.ts
+++ b/src/utils/parseI18nString/parseI18nString.test.ts
@@ -1,0 +1,31 @@
+import { parseI18nString } from './parseI18nString';
+
+describe('parseI18nString', () => {
+    it('should return empty string when given empty string', () => {
+        assertEquals(parseI18nString(''), resultOf``);
+    });
+
+    it('should return string when given string without substitutions', () => {
+        assertEquals(parseI18nString('string'), resultOf`string`);
+    });
+
+    it('should return string and one substitution when given string with one substitution', () => {
+        assertEquals(parseI18nString('string {substitution}'), resultOf`string ${`substitution`}`);
+    });
+
+    it('should return string and two substitutions when given string with two substitutions', () => {
+        assertEquals(parseI18nString('{substitution} string {substitution2}'), resultOf`${`substitution`} string ${`substitution2`}`);
+    });
+});
+
+function resultOf(strings: TemplateStringsArray, ...substitutions: unknown[]): [TemplateStringsArray, ...unknown[]] {
+    return [strings, ...substitutions];
+}
+
+function assertEquals(actual: [TemplateStringsArray, ...unknown[]], expected: [TemplateStringsArray, ...unknown[]]) {
+    // We cannot use `toEqual` because `raw` property does not play well with array comparison
+    expect(actual[0].raw).toEqual(expected[0].raw);
+    expect([...actual[0]]).toEqual([...expected[0]]);
+
+    expect(actual.slice(1)).toEqual(expected.slice(1));
+}

--- a/src/utils/parseI18nString/parseI18nString.test.ts
+++ b/src/utils/parseI18nString/parseI18nString.test.ts
@@ -16,6 +16,11 @@ describe('parseI18nString', () => {
     it('should return string and two substitutions when given string with two substitutions', () => {
         assertEquals(parseI18nString('{substitution} string {substitution2}'), resultOf`${`substitution`} string ${`substitution2`}`);
     });
+
+    /** Verifying full compliance with the specification */
+    it('should have inter-op with String.raw built-in function', () => {
+        expect(String.raw.apply(null, parseI18nString('string {substitution}'))).toBe(String.raw`string ${'substitution'}`);
+    });
 });
 
 function resultOf(strings: TemplateStringsArray, ...substitutions: unknown[]): [TemplateStringsArray, ...unknown[]] {

--- a/src/utils/parseI18nString/parseI18nString.ts
+++ b/src/utils/parseI18nString/parseI18nString.ts
@@ -1,0 +1,28 @@
+export function parseI18nString(str): [TemplateStringsArray, ...unknown[]] {
+    const strings: string[] = [];
+    const substitutions: string[] = [];
+
+    let startIndex = 0;
+    let endIndex = 0;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        startIndex = str.indexOf('{', endIndex);
+        if (startIndex === -1) {
+            strings.push(str.slice(endIndex));
+            break;
+        }
+
+        strings.push(str.slice(endIndex, startIndex));
+        endIndex = str.indexOf('}', startIndex);
+
+        if (endIndex === -1) {
+            throw new Error(`Missing closing brace } after position ${startIndex} in string: ${str}`);
+        }
+
+        substitutions.push(str.slice(startIndex + 1, endIndex));
+        endIndex++;
+    }
+
+    return [Object.assign(strings, { raw: [...strings] }), ...substitutions];
+}


### PR DESCRIPTION
This pull request improves the maintainability of transliteration to various Interslavic scripts, e.g.:

```js
"Tutoj kod možete viděti na {GitHub}."
```

The goal is to preserve substitutions (`{GitHub}`) while applying appropriate transliteration based on the selected alphabet (Latin, Cyrillic, or Glagolitic).

Introduced utility functions:

1. `parseI18nString`: Parses the translation string into an array of strings and substitutions for easier handling.
2. `createTaggedTemplate`: Creates a tagged template literal, allowing the application of transliteration functions to static string parts or interpolated values based on the passed transformation function (unknown => string). In our case, that are transliteration functions.

Example of tagged template literals:

```js
const greet = (strings, ...values) => {
  return `${strings[0]}${values[0]}${strings[1]}`;
};

const name = "Alice";
console.log(greet`Hello, ${name}!`); // Output: "Hello, Alice!"
```

Pros:

- Separation of concerns
- Clear, purpose-driven functions
- Improved readability and maintainability
- Test coverage
- Enable future extraction to libraries like `@interslavic/utils`

Cons:

- The solution is more wordy. 🤷‍♂️ but tested 💡  😄 