### PR TITLE
Fixed problems with search in cyrillic

### DIFF
--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -367,9 +367,7 @@ class DictionaryClass {
         }
 
         // option -etym - hard search by etymological orthography for Isv
-        const hardEtymSearch = from === 'isv' && (inputOptions.some((o) => o === 'etym') ||
-            (flavorisationType === '2' &&
-            isvReplacebleLetters.every((letter) => this.isvSearchLetters.from.includes(letter[0]))));
+        const hardEtymSearch = from === 'isv' && (inputOptions.some((o) => o === 'etym'));
 
         // filter by part of speech
         let filterPartOfSpeech = [];


### PR DESCRIPTION
If an user selects all possible options in the settings section 'Search sensitive letters for Interslavic', he can't use cyrillic letters for search in ethymological orthography. This problem is resolved here.

![image](https://github.com/sonic16x/interslavic/assets/56205890/cf2cb03f-2ef1-4f7a-ba79-02d316d079c0)

