### PR TITLE
fix: use strict transliteration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "25.2.0",
         "@ag-grid-community/core": "25.2.0",
-        "@interslavic/utils": "^2.3.2",
+        "@interslavic/utils": "^3.1.0",
         "classnames": "2.3.2",
         "lodash": "4.17.21",
         "md5": "2.3.0",
@@ -2404,9 +2404,9 @@
       "dev": true
     },
     "node_modules/@interslavic/utils": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@interslavic/utils/-/utils-2.3.2.tgz",
-      "integrity": "sha512-Lpe8UnQjUtMvNsy2g+wsJ5Co5la0ICq9KRudY88Dv8lM57N+Qq6ej+iVBr7mawgjK3IzxpmZKxr4MNK9eYOPTA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@interslavic/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-qeYHUMAvhfWuXs1yz8nXPEDJDQ0niYD0IU3pTx6eUHUCei9nZMv7lFYFwaJtoVDtqP4vrrXQncTT5QV8aiWZqg==",
       "dependencies": {
         "jest-allure2-reporter": "^2.0.0-beta.14",
         "tslib": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "25.2.0",
     "@ag-grid-community/core": "25.2.0",
-    "@interslavic/utils": "^2.3.2",
+    "@interslavic/utils": "^3.1.0",
     "classnames": "2.3.2",
     "lodash": "4.17.21",
     "md5": "2.3.0",

--- a/src/index.html.ejs
+++ b/src/index.html.ejs
@@ -64,8 +64,8 @@
   <h3>The project's name in different languages:</h3>
   <ul>
     <li lang="en">Interslavic Dictionary</li>
-    <li lang="art-Latn-x-interslavic">Medžuslovjansky slovnik</li>
-    <li lang="art-Cyrl-x-interslavic">Меджусловјанскы словник</li>
+    <li lang="isv-Latn">Medžuslovjansky slovnik</li>
+    <li lang="isv-Cyrl">Меджусловјанскы словник</li>
     <li lang="ru">Межславянский словарь</li>
     <li lang="uk">Міжслов'янський словник</li>
     <li lang="be">Міжславянскі слоўнік</li>

--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -546,7 +546,7 @@ class DictionaryClass {
         return this.percentsOfChecked;
     }
     public isvToEngLatin(text) {
-        return normalize(getLatin(text, '3'))
+        return normalize(getLatin(text, '3', true))
             .replace(/y/g, 'i');
     }
     public getField(item: string[], fieldName: string) {

--- a/src/utils/bcp47/bcp47.test.ts
+++ b/src/utils/bcp47/bcp47.test.ts
@@ -1,19 +1,11 @@
 import { toBCP47 } from 'utils/bcp47';
 
 describe('toBCP47', () => {
-    it('should convert "isv" to private extension of artificial language code', () => {
-        expect(toBCP47('isv')).toBe('art-x-isv');
-    });
-
-    it('should convert "isv-Latn" to art-x-isv-Latn', () => {
-        expect(toBCP47('isv-Latn')).toBe('art-x-isv-Latn');
-    });
-
     it('should convert "sr" to explictly Cyrillic Serbian (as for now)', () => {
         expect(toBCP47('sr')).toBe('sr-Cyrl');
     });
 
     it('should passthrough unknown language codes', () => {
-        expect(toBCP47('whatever')).toBe('whatever');
+        expect(toBCP47('isv')).toBe('isv');
     });
 });

--- a/src/utils/bcp47/bcp47.ts
+++ b/src/utils/bcp47/bcp47.ts
@@ -1,8 +1,4 @@
 export function toBCP47(code: string) {
-    if (code.startsWith('isv')) {
-        return code.replace('isv', 'art-x-isv');
-    }
-
     if (code === 'sr') {
         return 'sr-Cyrl';
     }

--- a/src/utils/getCyrillic/getCyrillic.ts
+++ b/src/utils/getCyrillic/getCyrillic.ts
@@ -1,16 +1,17 @@
 import { transliterate } from '@interslavic/utils';
 
-export function getCyrillic(text: string, flavorisationType: string): string {
+export function getCyrillic(text: string, flavorisationType: string, loose = false): string {
     if (!text) {
         return '';
     }
 
+    const strict = !loose;
     switch (flavorisationType) {
-        case '1': return transliterate(text, 'art-Cyrl-x-interslv-iotated-ext');
-        case '2': return transliterate(text, 'art-Cyrl-x-interslv-etym');
-        case '4': return transliterate(text, 'art-Cyrl-x-interslv-sloviant');
-        case 'J': return transliterate(text, 'art-Cyrl-x-interslv-southern');
-        case 'S': return transliterate(text, 'art-Cyrl-x-interslv-northern');
-        default: return transliterate(text, 'art-Cyrl-x-interslv');
+        case '1': return transliterate(text, 'isv-Cyrl-x-iotated-ext', strict);
+        case '2': return transliterate(text, 'isv-Cyrl-x-etymolog', strict);
+        case '4': return transliterate(text, 'isv-Cyrl-x-sloviant', strict);
+        case 'J': return transliterate(text, 'isv-Cyrl-x-southern', strict);
+        case 'S': return transliterate(text, 'isv-Cyrl-x-northern', strict);
+        default: return transliterate(text, 'isv-Cyrl', strict);
     }
 }

--- a/src/utils/getGlagolitic/getGlagolitic.ts
+++ b/src/utils/getGlagolitic/getGlagolitic.ts
@@ -1,15 +1,16 @@
 import { transliterate } from '@interslavic/utils';
 
-export function getGlagolitic(text: string, flavorisationType: string): string {
+export function getGlagolitic(text: string, flavorisationType: string, loose = false): string {
     if (!text) {
         return '';
     }
 
+    const strict = !loose;
     switch (flavorisationType) {
-        case '2': return transliterate(text, 'art-Glag-x-interslv-etym');
-        case '4': return transliterate(text, 'art-Glag-x-interslv-sloviant');
-        case 'J': return transliterate(text, 'art-Glag-x-interslv-southern');
-        case 'S': return transliterate(text, 'art-Glag-x-interslv-northern');
-        default: return transliterate(text, 'art-Glag-x-interslv');
+        case '2': return transliterate(text, 'isv-Glag-x-etymolog', strict);
+        case '4': return transliterate(text, 'isv-Glag-x-sloviant', strict);
+        case 'J': return transliterate(text, 'isv-Glag-x-southern', strict);
+        case 'S': return transliterate(text, 'isv-Glag-x-northern', strict);
+        default: return transliterate(text, 'isv-Glag', strict);
     }
 }

--- a/src/utils/getLatin/getLatin.ts
+++ b/src/utils/getLatin/getLatin.ts
@@ -1,18 +1,19 @@
 import { transliterate } from '@interslavic/utils';
 
-export function getLatin(text: string, flavorisationType: string): string {
+export function getLatin(text: string, flavorisationType: string, loose = false): string {
     if (!text) {
         return '';
     }
 
+    const strict = !loose;
     switch (flavorisationType) {
-        case '2': return transliterate(text, 'art-Latn-x-interslv-etym');
-        case '4': return transliterate(text, 'art-Latn-x-interslv-sloviant');
-        case 'J': return transliterate(text, 'art-Latn-x-interslv-southern');
+        case '2': return transliterate(text, 'isv-Latn-x-etymolog', strict);
+        case '4': return transliterate(text, 'isv-Latn-x-sloviant', strict);
+        case 'J': return transliterate(text, 'isv-Latn-x-southern', strict);
         case '1':
         case 'S':
-            return transliterate(text, 'art-Latn-x-interslv-northern');
+            return transliterate(text, 'isv-Latn-x-northern', strict);
         default:
-            return transliterate(text, 'art-Latn-x-interslv');
+            return transliterate(text, 'isv-Latn', strict);
     }
 }

--- a/src/utils/latinToIpa/latinToIpa.ts
+++ b/src/utils/latinToIpa/latinToIpa.ts
@@ -1,5 +1,5 @@
 import { transliterate } from '@interslavic/utils';
 
 export function latinToIpa(text: string) {
-    return transliterate(text, 'art-x-interslv-fonipa');
+    return transliterate(text, 'isv-x-fonipa');
 }


### PR DESCRIPTION
This pull request makes the transliteration function stricter – as the dictionary has no weird or non-standard scripts (cz=č, zs=ž, etc).