### PR TITLE
Feature: Improved display of cases for prepositions and some verbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "interslavic",
-  "version": "1.11.0",
+  "version": "1.18.4",
   "license": "MIT",
-  "description": "Interslavic dictionary",
+  "description": "Interslavic Dictionary",
   "author": "Sergey Cherebedov",
   "scripts": {
     "start": "npm run dev",

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -21,6 +21,7 @@ export enum ActionTypes {
     SET_NOTIFICATION = 'SET_NOTIFICATION',
     CHANGE_CARD_VIEW = 'CHANGE_CARD_VIEW',
     CHANGE_ORDER_OF_CASES = 'CHANGE_ORDER_OF_CASES',
+    CHANGE_CASE_QUESTIONS = 'CHANGE_CASE_QUESTIONS',
     DICTIONARY_LANGUAGES = 'DICTIONARY_LANGUAGES',
     TOGGLE_PAGE = 'TOGGLE_PAGE',
     SET_COMMUNITY_LINKS = 'SET_COMMUNITY_LINKS',
@@ -161,6 +162,13 @@ export function setAlphabets(data) {
 export function changeOrderOfCases(data) {
     return {
         type: ActionTypes.CHANGE_ORDER_OF_CASES,
+        data,
+    };
+}
+
+export function changeCaseQuestions(data) {
+    return {
+        type: ActionTypes.CHANGE_CASE_QUESTIONS,
         data,
     };
 }

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -1,8 +1,7 @@
 .checkbox {
   display: inline-flex;
-  margin: 0 8px 8px 0;
+  margin: 0 8px 4px 0;
   align-items: center;
-  height: 18px;
 
   &__input {
     position: absolute;

--- a/src/components/Pages/About/About.tsx
+++ b/src/components/Pages/About/About.tsx
@@ -108,7 +108,7 @@ export const About =
                         </div>
                         <hr/>
                         <div className="about-page__badges">
-                            <a
+                            {/*<a
                                 href="https://play.google.com/store/apps/details?id=org.interslavicdictionary.twa&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
                                 className="badge_google-play"
                                 title="Get it on Google Play"
@@ -120,7 +120,7 @@ export const About =
                                     width="200px"
                                     src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
                                 />
-                            </a>
+                            </a>*/}
 
                             <a
                                 href="https://discord.com/invite/n3saqm27QW"

--- a/src/components/Pages/Settings/Settings.tsx
+++ b/src/components/Pages/Settings/Settings.tsx
@@ -8,6 +8,7 @@ import { t } from 'translations';
 
 import {
     changeCardViewAction,
+    changeCaseQuestions,
     changeDictionaryLangAction,
     changeIsvSearchByWordForms,
     changeIsvSearchLetters,
@@ -23,6 +24,7 @@ import { fetchLang } from 'services/fetchDictionary';
 import { interfaceLanguageList } from 'services/interfaceLanguages';
 
 import { useAlphabets } from 'hooks/useAlphabets';
+import { useCaseQuestions } from 'hooks/useCaseQuestions';
 import { useDarkTheme } from 'hooks/useDarkTheme';
 import { useDictionaryLanguages } from 'hooks/useDictionaryLanguages';
 import { useEnabledPages } from 'hooks/useEnabledPages';
@@ -58,6 +60,7 @@ export const Settings =
         const isShortCardView = useShortCardView();
         const isDarkTheme = useDarkTheme();
         const isvSearchByWordForms = useIsvSearchByWordForms();
+        const caseQuestions = useCaseQuestions();
         const orderOfCases = useOrderOfCases();
         const dictionaryLanguages = useDictionaryLanguages();
         const enabledPages = useEnabledPages();
@@ -190,6 +193,13 @@ export const Settings =
                     })}
                     value={orderOfCases.join(',')}
                     onSelect={(orderOfCases: string) => dispatch(changeOrderOfCases(orderOfCases.split(',')))}
+                />
+                <hr/>
+                <Checkbox
+                    className="bold"
+                    title={t('caseQuestionsForPrepositions')}
+                    checked={caseQuestions}
+                    onChange={() => dispatch(changeCaseQuestions(!caseQuestions))}
                 />
                 <hr />
                 <h6 className="settings__add-langs-title">

--- a/src/components/ResultsCard/ResultsCard.scss
+++ b/src/components/ResultsCard/ResultsCard.scss
@@ -29,6 +29,7 @@
   .word + .word:before {
     content: "/";
     padding: 0 2px;
+    font-weight: normal;
   }
 
   .ipa {
@@ -36,7 +37,8 @@
     font-weight: 500;
   }
   .caseInfo {
-    font-style: italic;
+    font-weight: normal;
+    letter-spacing: -0.5pt;
   }
 
   &__details {
@@ -49,6 +51,9 @@
     font-size: var(--text-m);
     line-height: var(--text-m-line);
     color: var(--dark);
+    .caseInfo {
+      font-style: italic;
+    }
   }
 
 

--- a/src/components/ResultsCard/ResultsCard.scss
+++ b/src/components/ResultsCard/ResultsCard.scss
@@ -28,6 +28,7 @@
 
   .word + .word:before {
     content: "/";
+    padding: 0 2px;
   }
 
   .ipa {

--- a/src/components/ResultsCard/ResultsCard.scss
+++ b/src/components/ResultsCard/ResultsCard.scss
@@ -34,6 +34,9 @@
     color: var(--muted-text-color);
     font-weight: 500;
   }
+  .caseInfo {
+    font-style: italic;
+  }
 
   &__details {
     font-size: var(--text-m);

--- a/src/components/ResultsCard/ResultsCard.tsx
+++ b/src/components/ResultsCard/ResultsCard.tsx
@@ -11,7 +11,6 @@ import { biReporter, ICardAnalytics } from 'services/biReporter';
 import { Dictionary, ITranslateResult } from 'services/dictionary';
 
 import { useAlphabets } from 'hooks/useAlphabets';
-import { useCaseQuestions } from 'hooks/useCaseQuestions';
 import { useIntersect } from 'hooks/useIntersect';
 import { useLang } from 'hooks/useLang';
 import { useShortCardView } from 'hooks/useShortCardView';
@@ -36,7 +35,7 @@ interface IResultsCardProps {
     index: number;
 }
 
-function renderOriginal(item, alphabets, caseQuestions, index) {
+function renderOriginal(item, alphabets, index) {
     let latin = item.original;
     if (item.add) {
         latin += ` ${item.add}`;
@@ -90,7 +89,7 @@ function renderOriginal(item, alphabets, caseQuestions, index) {
                     />
                 );
             })} 
-            {item.caseInfo && <> <span className="caseInfo">(+{t(`case${item.caseInfo.slice(2,-1)}`)})</span></>}
+            {item.caseInfo && <> <span className="caseInfo">(+{t(`case${item.caseInfo.slice(1)}`)})</span></>}
             {item.ipa && <> <span className="ipa">[{item.ipa}]</span></>}
         </>
     );
@@ -99,7 +98,6 @@ function renderOriginal(item, alphabets, caseQuestions, index) {
 export const ResultsCard =
     ({ item, index }: IResultsCardProps) => {
         const alphabets = useAlphabets();
-        const caseQuestions = useCaseQuestions();
         const wordId = Dictionary.getField(item.raw, 'id').toString();
         const pos = getPartOfSpeech(item.details);
         const dispatch = useDispatch();
@@ -202,7 +200,7 @@ export const ResultsCard =
                             item={item}
                             lang={item.to}
                         />
-                    ) : renderOriginal(item, alphabets, caseQuestions, index)}
+                    ) : renderOriginal(item, alphabets, index)}
                     {'\u00A0'}
                     { hasIntelligibilityIssues(intelligibilityVector)
                         ? <button
@@ -232,7 +230,7 @@ export const ResultsCard =
                                 item={item}
                                 lang={item.from}
                             />
-                        ) : renderOriginal(item, alphabets, caseQuestions, index)}
+                        ) : renderOriginal(item, alphabets, index)}
                         {item.to !== 'isv' && short && (
                             <span className="results-card__details">{item.details}</span>
                         )}

--- a/src/components/ResultsCard/ResultsCard.tsx
+++ b/src/components/ResultsCard/ResultsCard.tsx
@@ -90,7 +90,7 @@ function renderOriginal(item, alphabets, caseQuestions, index) {
                     />
                 );
             })} 
-            {item.caseInfo && <> <span className="caseInfo">({t(`case${item.caseInfo.slice(2,-1)}`)})</span></>}
+            {item.caseInfo && <> <span className="caseInfo">(+{t(`case${item.caseInfo.slice(2,-1)}`)})</span></>}
             {item.ipa && <> <span className="ipa">[{item.ipa}]</span></>}
         </>
     );

--- a/src/components/ResultsCard/ResultsCard.tsx
+++ b/src/components/ResultsCard/ResultsCard.tsx
@@ -74,6 +74,8 @@ function renderOriginal(item, alphabets, index) {
         });
     }
 
+    const caseInfoTranslated = item.caseInfo ? `(${t(`case${item.caseInfo.slice(2,-1)}`)})` : '';
+
     return (
         <>
             {result.map(({ str, lang }, i) => {
@@ -88,7 +90,9 @@ function renderOriginal(item, alphabets, index) {
                         lang={lang}
                     />
                 );
-            })} {item.ipa && <span className="ipa">[{item.ipa}]</span>}
+            })} 
+            {item.caseInfo && <> <span className="caseInfo">{caseInfoTranslated}</span></>}
+            {item.ipa && <> <span className="ipa">[{item.ipa}]</span></>}
         </>
     );
 }

--- a/src/components/ResultsCard/ResultsCard.tsx
+++ b/src/components/ResultsCard/ResultsCard.tsx
@@ -11,6 +11,7 @@ import { biReporter, ICardAnalytics } from 'services/biReporter';
 import { Dictionary, ITranslateResult } from 'services/dictionary';
 
 import { useAlphabets } from 'hooks/useAlphabets';
+import { useCaseQuestions } from 'hooks/useCaseQuestions';
 import { useIntersect } from 'hooks/useIntersect';
 import { useLang } from 'hooks/useLang';
 import { useShortCardView } from 'hooks/useShortCardView';
@@ -35,7 +36,7 @@ interface IResultsCardProps {
     index: number;
 }
 
-function renderOriginal(item, alphabets, index) {
+function renderOriginal(item, alphabets, caseQuestions, index) {
     let latin = item.original;
     if (item.add) {
         latin += ` ${item.add}`;
@@ -74,8 +75,6 @@ function renderOriginal(item, alphabets, index) {
         });
     }
 
-    const caseInfoTranslated = item.caseInfo ? `(${t(`case${item.caseInfo.slice(2,-1)}`)})` : '';
-
     return (
         <>
             {result.map(({ str, lang }, i) => {
@@ -91,7 +90,7 @@ function renderOriginal(item, alphabets, index) {
                     />
                 );
             })} 
-            {item.caseInfo && <> <span className="caseInfo">{caseInfoTranslated}</span></>}
+            {item.caseInfo && <> <span className="caseInfo">({t(`case${item.caseInfo.slice(2,-1)}`)})</span></>}
             {item.ipa && <> <span className="ipa">[{item.ipa}]</span></>}
         </>
     );
@@ -100,6 +99,7 @@ function renderOriginal(item, alphabets, index) {
 export const ResultsCard =
     ({ item, index }: IResultsCardProps) => {
         const alphabets = useAlphabets();
+        const caseQuestions = useCaseQuestions();
         const wordId = Dictionary.getField(item.raw, 'id').toString();
         const pos = getPartOfSpeech(item.details);
         const dispatch = useDispatch();
@@ -202,7 +202,7 @@ export const ResultsCard =
                             item={item}
                             lang={item.to}
                         />
-                    ) : renderOriginal(item, alphabets, index)}
+                    ) : renderOriginal(item, alphabets, caseQuestions, index)}
                     {'\u00A0'}
                     { hasIntelligibilityIssues(intelligibilityVector)
                         ? <button
@@ -232,7 +232,7 @@ export const ResultsCard =
                                 item={item}
                                 lang={item.from}
                             />
-                        ) : renderOriginal(item, alphabets, index)}
+                        ) : renderOriginal(item, alphabets, caseQuestions, index)}
                         {item.to !== 'isv' && short && (
                             <span className="results-card__details">{item.details}</span>
                         )}

--- a/src/hooks/useCaseQuestions.ts
+++ b/src/hooks/useCaseQuestions.ts
@@ -1,0 +1,7 @@
+import { useSelector } from 'react-redux';
+
+import { IMainState } from 'reducers';
+
+export function useCaseQuestions() {
+    return useSelector((state: IMainState) => state.caseQuestions);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,7 +65,7 @@ export const defaultState: IMainState = {
         to: [],
     },
     isvSearchByWordForms: true,
-    caseQuestions: false,
+    caseQuestions: true,
     fromText: '',
     searchType: 'begin',
     posFilter: '',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,6 +65,7 @@ export const defaultState: IMainState = {
         to: [],
     },
     isvSearchByWordForms: true,
+    caseQuestions: false,
     fromText: '',
     searchType: 'begin',
     posFilter: '',

--- a/src/reducers/reducers.ts
+++ b/src/reducers/reducers.ts
@@ -51,6 +51,7 @@ export interface IMainState {
         to: string[]
     };
     isvSearchByWordForms: boolean;
+    caseQuestions: boolean;
     fromText: string;
     searchType: string;
     posFilter: string;
@@ -91,7 +92,7 @@ export function mainReducer(state: IMainState, { type, data }) {
                 ...state,
                 lang,
                 rawResults,
-                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets),
+                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets, state.caseQuestions),
             };
         }
         case ActionTypes.SEARCH_TYPE: {
@@ -111,7 +112,7 @@ export function mainReducer(state: IMainState, { type, data }) {
                 ...state,
                 searchType,
                 rawResults,
-                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets),
+                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets, state.caseQuestions),
             };
         }
         case ActionTypes.FROM_TEXT: {
@@ -131,7 +132,7 @@ export function mainReducer(state: IMainState, { type, data }) {
                 ...state,
                 fromText,
                 rawResults,
-                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets),
+                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets, state.caseQuestions),
             };
         }
         case ActionTypes.RUN_SEARCH: {
@@ -149,7 +150,7 @@ export function mainReducer(state: IMainState, { type, data }) {
             return {
                 ...state,
                 rawResults,
-                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets),
+                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets, state.caseQuestions),
             };
         }
         case ActionTypes.CHANGE_ISV_SEARCH_LETTERS: {
@@ -169,7 +170,7 @@ export function mainReducer(state: IMainState, { type, data }) {
                 ...state,
                 isvSearchLetters,
                 rawResults,
-                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets),
+                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets, state.caseQuestions),
             };
         }
         case ActionTypes.CHANGE_ISV_SEARCH_BY_WORDFORMS: {
@@ -190,9 +191,10 @@ export function mainReducer(state: IMainState, { type, data }) {
                 ...state,
                 isvSearchByWordForms,
                 rawResults,
-                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets),
+                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets, state.caseQuestions),
             };
         }
+
         case ActionTypes.FLAVORISATION_TYPE: {
             const { searchType, lang, fromText, posFilter } = state;
             const [rawResults, translateTime] = Dictionary.translate({
@@ -208,7 +210,7 @@ export function mainReducer(state: IMainState, { type, data }) {
             return {
                 ...state,
                 flavorisationType: data,
-                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, data, state.alphabets),
+                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, data, state.alphabets, state.caseQuestions),
             };
         }
         case ActionTypes.POS_FILTER: {
@@ -226,7 +228,7 @@ export function mainReducer(state: IMainState, { type, data }) {
             return {
                 ...state,
                 posFilter: data,
-                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets),
+                results: Dictionary.formatTranslate(rawResults, lang.from, lang.to, flavorisationType, state.alphabets, state.caseQuestions),
             };
         }
         case ActionTypes.SET_PAGE:
@@ -324,14 +326,26 @@ export function mainReducer(state: IMainState, { type, data }) {
                 ...state,
                 alphabets,
                 alphabetType,
-                results: Dictionary.formatTranslate(state.rawResults, state.lang.from, state.lang.to, state.flavorisationType, alphabets),
+                results: Dictionary.formatTranslate(state.rawResults, state.lang.from, state.lang.to, state.flavorisationType, alphabets, state.caseQuestions),
             };
         }
+
+        case ActionTypes.CHANGE_CASE_QUESTIONS: {
+            const caseQuestions = data;
+            
+            return {
+                ...state,
+                caseQuestions,
+                results: Dictionary.formatTranslate(state.rawResults, state.lang.from, state.lang.to, state.flavorisationType, state.alphabets, caseQuestions),
+            };
+        }
+
         case ActionTypes.CHANGE_ORDER_OF_CASES:
             return {
                 ...state,
                 orderOfCases: data,
             };
+
         case ActionTypes.TOGGLE_PAGE: {
             const { enabledPages } = state;
 

--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -5,6 +5,7 @@ import { IAlphabets } from 'reducers';
 import { convertCases } from 'utils/convertCases';
 import { filterLatin } from 'utils/filterLatin';
 import { filterNiqqud } from 'utils/filterNiqqud';
+import { getCaseTips } from 'utils/getCaseTips';
 import { getCyrillic } from 'utils/getCyrillic';
 import { getGlagolitic } from 'utils/getGlagolitic';
 import { getLatin } from 'utils/getLatin';
@@ -513,18 +514,23 @@ class DictionaryClass {
         to: string,
         flavorisationType: string,
         alphabets?: IAlphabets,
+        caseQuestions?: boolean
     ): ITranslateResult[] {
         return results.map((item) => {
             const isv = this.getField(item, 'isv');
             const addArray = this.getField(item, 'addition').match(/\(.+?\)/) || [];
-            const add = addArray.find((elem) => elem.indexOf('(+') === -1) || '';
-            const caseInfo = addArray.find((elem) => elem.indexOf('(+') !== -1) || '';
+            let add = addArray.find((elem) => elem.indexOf('(+') === -1) || '';
+            let caseInfo = convertCases(addArray.find((elem) => elem.indexOf('(+') !== -1) || '');
+            if(caseInfo && caseQuestions) {
+                add = `${add?`${add} `:''}(${getCaseTips(caseInfo.slice(2,3),'nounShort')})`;
+                caseInfo = '';
+            }
             const translate = this.getField(item, (from === 'isv' ? to : from));
             const formattedItem: ITranslateResult = {
                 translate: removeExclamationMark(translate),
                 original: getLatin(isv, flavorisationType),
                 add: getLatin(add, flavorisationType),
-                caseInfo: convertCases(caseInfo),
+                caseInfo: caseInfo,
                 details: this.getField(item, 'partOfSpeech'),
                 ipa: latinToIpa(getLatin(removeBrackets(isv, '[', ']'), flavorisationType)),
                 checked: translate[0] !== '!',

--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -131,6 +131,7 @@ export interface ITranslateResult {
     add: string;
     addCyr?: string;
     addGla?: string;
+    caseInfo: string;
     details: string;
     ipa: string;
     isv: string;
@@ -515,12 +516,15 @@ class DictionaryClass {
     ): ITranslateResult[] {
         return results.map((item) => {
             const isv = this.getField(item, 'isv');
-            const add = this.getField(item, 'addition');
+            const addArray = this.getField(item, 'addition').match(/\(.+?\)/) || [];
+            const add = addArray.find((elem) => elem.indexOf('(+') === -1) || '';
+            const caseInfo = addArray.find((elem) => elem.indexOf('(+') !== -1) || '';
             const translate = this.getField(item, (from === 'isv' ? to : from));
             const formattedItem: ITranslateResult = {
                 translate: removeExclamationMark(translate),
                 original: getLatin(isv, flavorisationType),
-                add: convertCases(getLatin(add, flavorisationType)),
+                add: getLatin(add, flavorisationType),
+                caseInfo: convertCases(caseInfo),
                 details: this.getField(item, 'partOfSpeech'),
                 ipa: latinToIpa(getLatin(removeBrackets(isv, '[', ']'), flavorisationType)),
                 checked: translate[0] !== '!',
@@ -531,11 +535,11 @@ class DictionaryClass {
             };
             if (alphabets?.cyrillic) {
                 formattedItem.originalCyr = getCyrillic(isv, flavorisationType);
-                formattedItem.addCyr = convertCases(getCyrillic(add, flavorisationType));
+                formattedItem.addCyr = getCyrillic(add, flavorisationType);
             }
             if (alphabets?.glagolitic) {
                 formattedItem.originalGla = getGlagolitic(isv, flavorisationType);
-                formattedItem.addGla = convertCases(getGlagolitic(add, flavorisationType));
+                formattedItem.addGla = getGlagolitic(add, flavorisationType);
             }
 
             return formattedItem;

--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -519,10 +519,10 @@ class DictionaryClass {
         return results.map((item) => {
             const isv = this.getField(item, 'isv');
             const addArray = this.getField(item, 'addition').match(/\(.+?\)/) || [];
-            let add = addArray.find((elem) => elem.indexOf('(+') === -1) || '';
-            let caseInfo = convertCases(addArray.find((elem) => elem.indexOf('(+') !== -1) || '');
+            let add = addArray.find((elem) => !elem.startsWith('(+')) || '';
+            let caseInfo = convertCases(addArray.find((elem) => elem.startsWith('(+'))?.slice(1,-1) || '');
             if(caseInfo && caseQuestions) {
-                add = `${add?`${add} `:''}(${getCaseTips(caseInfo.slice(2,3),'nounShort')})`;
+                add = `${add?`${add} `:''}(${getCaseTips(caseInfo.slice(1),'nounShort')})`;
                 caseInfo = '';
             }
             const translate = this.getField(item, (from === 'isv' ? to : from));

--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -133,6 +133,8 @@ export interface ITranslateResult {
     addCyr?: string;
     addGla?: string;
     caseInfo: string;
+    caseInfoCyr?: string;
+    caseInfoGla?: string;
     details: string;
     ipa: string;
     isv: string;
@@ -519,11 +521,10 @@ class DictionaryClass {
         return results.map((item) => {
             const isv = this.getField(item, 'isv');
             const addArray = this.getField(item, 'addition').match(/\(.+?\)/) || [];
-            let add = addArray.find((elem) => !elem.startsWith('(+')) || '';
+            const add = addArray.find((elem) => !elem.startsWith('(+')) || '';
             let caseInfo = convertCases(addArray.find((elem) => elem.startsWith('(+'))?.slice(1,-1) || '');
             if(caseInfo && caseQuestions) {
-                add = `${add?`${add} `:''}(${getCaseTips(caseInfo.slice(1),'nounShort')})`;
-                caseInfo = '';
+                caseInfo = getCaseTips(caseInfo.slice(1),'nounShort');
             }
             const translate = this.getField(item, (from === 'isv' ? to : from));
             const formattedItem: ITranslateResult = {
@@ -542,10 +543,12 @@ class DictionaryClass {
             if (alphabets?.cyrillic) {
                 formattedItem.originalCyr = getCyrillic(isv, flavorisationType);
                 formattedItem.addCyr = getCyrillic(add, flavorisationType);
+                if(caseQuestions) formattedItem.caseInfoCyr = getCyrillic(caseInfo, flavorisationType);
             }
             if (alphabets?.glagolitic) {
                 formattedItem.originalGla = getGlagolitic(isv, flavorisationType);
                 formattedItem.addGla = getGlagolitic(add, flavorisationType);
+                if(caseQuestions) formattedItem.caseInfoGla = getGlagolitic(caseInfo, flavorisationType);
             }
 
             return formattedItem;

--- a/src/translations/data.json
+++ b/src/translations/data.json
@@ -2791,19 +2791,19 @@
     "bg": "Последователност на падежите"
   },
   "caseQuestionsForPrepositions": {
-    "en": "Show questions instead of case names in search results (for prepositions and some verbs)",
-    "isv": "Pokazyvati pytańja zaměsto nazv padežev v rezultatah iskańja (pri prědlogah i někojih glagolah)",
-    "ru": "Показывать вопросы вместо названий падежей в результатах поиска (при предлогах и некоторых глаголах)",
-    "uk": "Показувати питання замість назв відмінків у результатах пошуку (при прийменниках та деяких дієсловах)",
-    "be": "Паказваць пытанні замест назваў склонаў у выніках пошуку (пры падставах і некаторых дзеясловах)",
-    "pl": "Pokaż pytania zamiast nazw przypadków w wynikach wyszukiwania (dla przyimków i niektórych czasowników)",
-    "cs": "Zobrazovat otázky místo názvů pádů ve výsledcích vyhledávání (pro předložky a některá slovesa)",
-    "sk": "Zobrazovať otázky namiesto názvov pádov v výsledkoch vyhľadávania (pre predložky a niektoré slovesá)",
-    "sl": "Pokazati vprašanja namesto imen sklonov v rezultatih iskanja (za predlogi in nekatere glagole)",
-    "hr": "Prikazati pitanja umjesto imena padeža u rezultatima pretraživanja (za predloške i neke glagole)",
-    "sr": "Покажи питања уместо имена падежа у резултатима претраге (за предлоге и неке глаголе)",
-    "mk": "Покажи прашања наместо имената на падежите во резултатите од пребарувањето (за предлошките и некои глаголи)",
-    "bg": "Покажи въпросите вместо имената на падежите в резултатите от търсенето (за предлозите и някои глаголи)"
+    "en": "Show case questions instead of case names for prepositions and some verbs",
+    "isv": "Pokazyvati padežne pytańja zaměsto nazv padežev pri prědlogah i někojih glagolah",
+    "ru": "Отображать падежные вопросы вместо названий падежей при предлогах и некоторых глаголах",
+    "uk": "Показувати відмінкові запитання замість назв відмінків при прийменниках та деяких дієсловах",
+    "be": "Паказваць склонныя пытанні замест назваў склонаў пры падставах і некаторых дзеясловах",
+    "pl": "Pokaż pytania przypadkowe zamiast nazw przypadków przy przyimkach i niektórych czasownikach",
+    "cs": "Zobrazit pádové otázky místo názvů pádů u předložek a některých sloves",
+    "sk": "Zobraziť pádové otázky namiesto názvov pádov pri predložkách a niektorých slovesách",
+    "sl": "Pokazati sklonilne vprašanja namesto imen sklonov pri predlogih in nekaterih glagolih",
+    "hr": "Prikazati padežna pitanja umjesto naziva padeža kod prijedloga i nekih glagola",
+    "sr": "Покажи падежна питања уместо назива падежа код предлога и неких глагола",
+    "mk": "Покажи падежни прашања наместо имиња на падежите при предлози и некои глаголи",
+    "bg": "Покажи падежни въпроси вместо имена на падежите при предлози и някои глаголи"
   },
   "close": {
     "en": "Close",

--- a/src/translations/data.json
+++ b/src/translations/data.json
@@ -2791,19 +2791,19 @@
     "bg": "Последователност на падежите"
   },
   "caseQuestionsForPrepositions": {
-    "en": "Show case questions instead of case names for prepositions and some verbs",
-    "isv": "Pokazyvati padežne pytańja zaměsto nazv padežev pri prědlogah i někojih glagolah",
-    "ru": "Отображать падежные вопросы вместо названий падежей при предлогах и некоторых глаголах",
-    "uk": "Показувати відмінкові запитання замість назв відмінків при прийменниках та деяких дієсловах",
-    "be": "Паказваць склонныя пытанні замест назваў склонаў пры падставах і некаторых дзеясловах",
-    "pl": "Pokaż pytania przypadkowe zamiast nazw przypadków przy przyimkach i niektórych czasownikach",
-    "cs": "Zobrazit pádové otázky místo názvů pádů u předložek a některých sloves",
-    "sk": "Zobraziť pádové otázky namiesto názvov pádov pri predložkách a niektorých slovesách",
-    "sl": "Pokazati sklonilne vprašanja namesto imen sklonov pri predlogih in nekaterih glagolih",
-    "hr": "Prikazati padežna pitanja umjesto naziva padeža kod prijedloga i nekih glagola",
-    "sr": "Покажи падежна питања уместо назива падежа код предлога и неких глагола",
-    "mk": "Покажи падежни прашања наместо имиња на падежите при предлози и некои глаголи",
-    "bg": "Покажи падежни въпроси вместо имена на падежите при предлози и някои глаголи"
+    "en": "Show case questions instead of case names for prepositions and verbs",
+    "isv": "Pokazyvati padežne pytańja zaměsto nazv padežev pri prědlogah i glagolah",
+    "ru": "Отображать падежные вопросы вместо названий падежей при предлогах и глаголах",
+    "uk": "Показувати відмінкові запитання замість назв відмінків при прийменниках та дієсловах",
+    "be": "Паказваць склонныя пытанні замест назваў склонаў пры падставах і дзеясловах",
+    "pl": "Pokaż pytania przypadkowe zamiast nazw przypadków przy przyimkach i czasownikach",
+    "cs": "Zobrazit pádové otázky místo názvů pádů u předložek a sloves",
+    "sk": "Zobraziť pádové otázky namiesto názvov pádov pri predložkách a slovesách",
+    "sl": "Pokazati sklonilne vprašanja namesto imen sklonov pri predlogih in glagolih",
+    "hr": "Prikazati padežna pitanja umjesto naziva padeža kod prijedloga i glagola",
+    "sr": "Покажи падежна питања уместо назива падежа код предлога и глагола",
+    "mk": "Покажи падежни прашања наместо имиња на падежите при предлози и глаголи",
+    "bg": "Покажи падежни въпроси вместо имена на падежите при предлози и глаголи"
   },
   "close": {
     "en": "Close",

--- a/src/translations/data.json
+++ b/src/translations/data.json
@@ -2790,6 +2790,21 @@
     "mk": "Редослед на падежите",
     "bg": "Последователност на падежите"
   },
+  "caseQuestionsForPrepositions": {
+    "en": "Show questions instead of case names in search results (for prepositions and some verbs)",
+    "isv": "Pokazyvati pytańja zaměsto nazv padežev v rezultatah iskańja (pri prědlogah i někojih glagolah)",
+    "ru": "Показывать вопросы вместо названий падежей в результатах поиска (при предлогах и некоторых глаголах)",
+    "uk": "Показувати питання замість назв відмінків у результатах пошуку (при прийменниках та деяких дієсловах)",
+    "be": "Паказваць пытанні замест назваў склонаў у выніках пошуку (пры падставах і некаторых дзеясловах)",
+    "pl": "Pokaż pytania zamiast nazw przypadków w wynikach wyszukiwania (dla przyimków i niektórych czasowników)",
+    "cs": "Zobrazovat otázky místo názvů pádů ve výsledcích vyhledávání (pro předložky a některá slovesa)",
+    "sk": "Zobrazovať otázky namiesto názvov pádov v výsledkoch vyhľadávania (pre predložky a niektoré slovesá)",
+    "sl": "Pokazati vprašanja namesto imen sklonov v rezultatih iskanja (za predlogi in nekatere glagole)",
+    "hr": "Prikazati pitanja umjesto imena padeža u rezultatima pretraživanja (za predloške i neke glagole)",
+    "sr": "Покажи питања уместо имена падежа у резултатима претраге (за предлоге и неке глаголе)",
+    "mk": "Покажи прашања наместо имената на падежите во резултатите од пребарувањето (за предлошките и некои глаголи)",
+    "bg": "Покажи въпросите вместо имената на падежите в резултатите от търсенето (за предлозите и някои глаголи)"
+  },
   "close": {
     "en": "Close",
     "isv": "Zatvoriti",

--- a/src/utils/convertCases/convertCases.test.ts
+++ b/src/utils/convertCases/convertCases.test.ts
@@ -1,49 +1,31 @@
 import { convertCases } from 'utils/convertCases';
 
 describe('convertCases', () => {
-    it('should convert "+1" to +Nom', () => {
-        expect(convertCases('+1')).toBe('+Nom');
+    test.each([
+        ['+1', '+Nom'],
+        ['+2', '+Gen'],
+        ['+3', '+Dat'],
+        ['+4', '+Acc'],
+        ['+5', '+Ins'],
+        ['+6', '+Loc'],
+        ['+7', '+Voc']
+    ])('should convert "%s" to "%s"', (input, expected) => {
+        expect(convertCases(input)).toBe(expected);
     });
-    it('should convert "+2" to +Gen', () => {
-        expect(convertCases('+2')).toBe('+Gen');
+    
+    test.each([
+        ['+Nom.', '+Nom'],
+        ['+Gen.', '+Gen'],
+        ['+Dat.', '+Dat'],
+        ['+Acc.', '+Acc'],
+        ['+Ins.', '+Ins'],
+        ['+Loc.', '+Loc'],
+        ['+Voc.', '+Voc']
+    ])('should remove dot from "%s"', (input, expected) => {
+        expect(convertCases(input)).toBe(expected);
     });
-    it('should convert "+3" to +Dat', () => {
-        expect(convertCases('+3')).toBe('+Dat');
-    });
-    it('should convert "+4" to +Acc', () => {
-        expect(convertCases('+4')).toBe('+Acc');
-    });
-    it('should convert "+5" to +Ins', () => {
-        expect(convertCases('+5')).toBe('+Ins');
-    });
-    it('should convert "+6" to +Loc', () => {
-        expect(convertCases('+6')).toBe('+Loc');
-    });
-    it('should convert "+7" to +Voc', () => {
-        expect(convertCases('+7')).toBe('+Voc');
-    });
-    it('should convert "+Nom" to +Nom', () => {
-        expect(convertCases('+Nom')).toBe('+Nom');
-    });
-    it('should convert "+Gen" to +Gen', () => {
-        expect(convertCases('+Gen')).toBe('+Gen');
-    });
-    it('should convert "+Dat" to +Dat', () => {
-        expect(convertCases('+Dat')).toBe('+Dat');
-    });
-    it('should convert "+Acc" to +Acc', () => {
-        expect(convertCases('+Acc')).toBe('+Acc');
-    });
-    it('should convert "+Ins" to +Ins', () => {
-        expect(convertCases('+Ins')).toBe('+Ins');
-    });
-    it('should convert "+Loc" to +Loc', () => {
-        expect(convertCases('+Loc')).toBe('+Loc');
-    });
-    it('should convert "+Voc" to +Voc', () => {
-        expect(convertCases('+Voc')).toBe('+Voc');
-    });
-    it('should convert "+ABCD" to Empty string', () => {
+    
+    test('should convert unknown abbreviations to an empty string', () => {
         expect(convertCases('+ABCD')).toBe('');
     });
 });

--- a/src/utils/convertCases/convertCases.test.ts
+++ b/src/utils/convertCases/convertCases.test.ts
@@ -1,19 +1,49 @@
 import { convertCases } from 'utils/convertCases';
 
 describe('convertCases', () => {
-    it('should convert "+2" to +Gen.', () => {
-        expect(convertCases('+2')).toBe('+Gen.');
+    it('should convert "+1" to +Nom', () => {
+        expect(convertCases('+1')).toBe('+Nom');
     });
-    it('should convert "+3" to +Dat.', () => {
-        expect(convertCases('+3')).toBe('+Dat.');
+    it('should convert "+2" to +Gen', () => {
+        expect(convertCases('+2')).toBe('+Gen');
     });
-    it('should convert "+4" to +Acc.', () => {
-        expect(convertCases('+4')).toBe('+Acc.');
+    it('should convert "+3" to +Dat', () => {
+        expect(convertCases('+3')).toBe('+Dat');
     });
-    it('should convert "+5" to +Ins.', () => {
-        expect(convertCases('+5')).toBe('+Ins.');
+    it('should convert "+4" to +Acc', () => {
+        expect(convertCases('+4')).toBe('+Acc');
     });
-    it('should convert "+6" to +Loc.', () => {
-        expect(convertCases('+6')).toBe('+Loc.');
+    it('should convert "+5" to +Ins', () => {
+        expect(convertCases('+5')).toBe('+Ins');
+    });
+    it('should convert "+6" to +Loc', () => {
+        expect(convertCases('+6')).toBe('+Loc');
+    });
+    it('should convert "+7" to +Voc', () => {
+        expect(convertCases('+7')).toBe('+Voc');
+    });
+    it('should convert "+Nom" to +Nom', () => {
+        expect(convertCases('+Nom')).toBe('+Nom');
+    });
+    it('should convert "+Gen" to +Gen', () => {
+        expect(convertCases('+Gen')).toBe('+Gen');
+    });
+    it('should convert "+Dat" to +Dat', () => {
+        expect(convertCases('+Dat')).toBe('+Dat');
+    });
+    it('should convert "+Acc" to +Acc', () => {
+        expect(convertCases('+Acc')).toBe('+Acc');
+    });
+    it('should convert "+Ins" to +Ins', () => {
+        expect(convertCases('+Ins')).toBe('+Ins');
+    });
+    it('should convert "+Loc" to +Loc', () => {
+        expect(convertCases('+Loc')).toBe('+Loc');
+    });
+    it('should convert "+Voc" to +Voc', () => {
+        expect(convertCases('+Voc')).toBe('+Voc');
+    });
+    it('should convert "+ABCD" to Empty string', () => {
+        expect(convertCases('+ABCD')).toBe('');
     });
 });

--- a/src/utils/convertCases/convertCases.ts
+++ b/src/utils/convertCases/convertCases.ts
@@ -1,5 +1,6 @@
-export function convertCases(add: string): string {
-    const caseInfo = add
+export function convertCases(caseInfoRaw: string): string {
+    const caseList = ['+Nom','+Gen','+Dat','+Acc','+Ins','+Loc','+Voc'];
+    const caseInfo = caseInfoRaw
         .replace('+1', '+Nom')
         .replace('+2', '+Gen')
         .replace('+3', '+Dat')
@@ -8,6 +9,6 @@ export function convertCases(add: string): string {
         .replace('+6', '+Loc')
         .replace('+7', '+Voc')
         .replace('.', ''); 
-    
-    return ['+Nom','+Gen','+Dat','+Acc','+Ins','+Loc','+Voc'].find((el) => caseInfo.indexOf(el) !== -1) ? caseInfo : '';
+
+    return caseList.includes(caseInfo) ? caseInfo : '';
 }

--- a/src/utils/convertCases/convertCases.ts
+++ b/src/utils/convertCases/convertCases.ts
@@ -1,8 +1,13 @@
 export function convertCases(add: string): string {
     return add
-        .replace('+2', '+Gen.')
-        .replace('+3', '+Dat.')
-        .replace('+4', '+Acc.')
-        .replace('+5', '+Ins.')
-        .replace('+6', '+Loc.');
+        .replace('+1', '+Nom')
+        .replace('+2', '+Gen')
+        .replace('+3', '+Dat')
+        .replace('+4', '+Acc')
+        .replace('+5', '+Ins')
+        .replace('+6', '+Loc')
+        .replace('+7', '+Voc')
+        .replace('.', '')
+        .replace(/\((?!\+Nom|\+Gen|\+Dat|\+Acc|\+Ins|\+Loc|\+Voc).*\)/,'')
+    ;
 }

--- a/src/utils/convertCases/convertCases.ts
+++ b/src/utils/convertCases/convertCases.ts
@@ -1,5 +1,5 @@
 export function convertCases(add: string): string {
-    return add
+    const caseInfo = add
         .replace('+1', '+Nom')
         .replace('+2', '+Gen')
         .replace('+3', '+Dat')
@@ -7,7 +7,7 @@ export function convertCases(add: string): string {
         .replace('+5', '+Ins')
         .replace('+6', '+Loc')
         .replace('+7', '+Voc')
-        .replace('.', '')
-        .replace(/\((?!\+Nom|\+Gen|\+Dat|\+Acc|\+Ins|\+Loc|\+Voc).*\)/,'')
-    ;
+        .replace('.', ''); 
+    
+    return ['+Nom','+Gen','+Dat','+Acc','+Ins','+Loc','+Voc'].find((el) => caseInfo.indexOf(el) !== -1) ? caseInfo : '';
 }

--- a/src/utils/convertCases/convertCases.ts
+++ b/src/utils/convertCases/convertCases.ts
@@ -1,5 +1,6 @@
+const caseList = ['+Nom','+Gen','+Dat','+Acc','+Ins','+Loc','+Voc'];
+
 export function convertCases(caseInfoRaw: string): string {
-    const caseList = ['+Nom','+Gen','+Dat','+Acc','+Ins','+Loc','+Voc'];
     const caseInfo = caseInfoRaw
         .replace('+1', '+Nom')
         .replace('+2', '+Gen')

--- a/src/utils/getCaseTips/getCaseTips.ts
+++ b/src/utils/getCaseTips/getCaseTips.ts
@@ -1,7 +1,7 @@
 export function getCaseTips(caseName: string, setName: string): string {
     switch(setName) {
         case 'noun': 
-            switch(caseName.slice(0,1).toUpperCase()) {
+            switch(caseName[0]?.toUpperCase()) {
                 case 'N': return 'kto? čto?';
                 case 'A': return 'kogo? čto?';
                 case 'G': return 'kogo? čego?';
@@ -12,7 +12,7 @@ export function getCaseTips(caseName: string, setName: string): string {
                 default: return '';
             }
         case 'nounShort': 
-            switch(caseName.slice(0,1).toUpperCase()) {
+            switch(caseName[0]?.toUpperCase()) {
                 case 'N': return 'kto? čto?';
                 case 'A': return 'kogo? čto?';
                 case 'G': return 'kogo? čego?';
@@ -23,7 +23,7 @@ export function getCaseTips(caseName: string, setName: string): string {
                 default: return '';
             }
         case 'adjectiveSingular': 
-            switch(caseName.slice(0,1).toUpperCase()) {
+            switch(caseName[0]?.toUpperCase()) {
                 case 'N': return 'kaky? kako? kaka?';
                 case 'A': return 'kakogo? kako? kaku?';
                 case 'G': return 'kakogo? kakoj?';
@@ -34,7 +34,7 @@ export function getCaseTips(caseName: string, setName: string): string {
                 default: return '';
             }
         case 'adjectivePlural': 
-            switch(caseName.slice(0,1).toUpperCase()) {
+            switch(caseName[0]?.toUpperCase()) {
                 case 'N': return 'kaki? kake?';
                 case 'A': return 'kakyh? kake?';
                 case 'G': return 'kakyh?';

--- a/src/utils/getCaseTips/getCaseTips.ts
+++ b/src/utils/getCaseTips/getCaseTips.ts
@@ -11,6 +11,17 @@ export function getCaseTips(caseName: string, setName: string): string {
                 case 'V': return 'hej! ty! vy!';
                 default: return '';
             }
+        case 'nounShort': 
+            switch(caseName.slice(0,1).toUpperCase()) {
+                case 'N': return 'kto? čto?';
+                case 'A': return 'kogo? čto?';
+                case 'G': return 'kogo? čego?';
+                case 'D': return 'komu? čemu?';
+                case 'I': return 'kym? čim?';
+                case 'L': return 'kom? čem?';
+                case 'V': return 'hej!';
+                default: return '';
+            }
         case 'adjectiveSingular': 
             switch(caseName.slice(0,1).toUpperCase()) {
                 case 'N': return 'kaky? kako? kaka?';


### PR DESCRIPTION
Resolves #120 

Prepositions and some verbs in the database have an indication of the case with which they are used.
Added:
1. Display the case names in the selected interface language.
2. A new settings item for displaying case questions instead of case names.

![image](https://github.com/sonic16x/interslavic/assets/56205890/b2b8bedf-518b-4f38-80c9-427a9640c2a2)
