### PR TITLE
fix: fixed search interslavic words using cyrillic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "interslavic",
-  "version": "1.11.0",
+  "version": "1.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "interslavic",
-      "version": "1.11.0",
+      "version": "1.18.4",
       "license": "MIT",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "25.2.0",

--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -361,10 +361,9 @@ class DictionaryClass {
             if (flavorisationType === '2' && this.isvSearchLetters.from.includes('ȯ')) {
                 isvText = isvText.replace(/[ȯòъ]/g, '{ȯ}');
             }
-            isvText = this.applyIsvSearchLetters(getLatin(isvText, flavorisationType), flavorisationType);
+            isvText = this.applyIsvSearchLetters(getLatin(isvText, flavorisationType, true), flavorisationType);
             isvText = this.inputPrepare('isv-src', isvText);
         }
-
         // option -end - search by ending of word
         if (inputOptions.some((option) => option.trim() === 'end')) {
             searchType = 'end';
@@ -425,7 +424,7 @@ class DictionaryClass {
                         return false;
                     }
                 }
-
+                
                 return filterResult;
             })
             .filter((item) => {
@@ -442,14 +441,13 @@ class DictionaryClass {
                     filterResult = splittedField.some((chunk) => (
                         searchTypes[searchType](this.applyIsvSearchLetters(chunk, flavorisationType), isvText)
                     ));
-
                 }
                 if (!filterResult && (to === 'isv' || twoWaySearch)) {
                     const splittedField = this.getSplittedField(lang, item);
                     filterResult = filterResult ||
                         splittedField.some((chunk) => searchTypes[searchType](chunk, inputLangPrepared));
                 }
-
+                
                 return filterResult;
             })
             .map((item) => {


### PR DESCRIPTION
Before (see on [#286](https://github.com/sonic16x/interslavic/pull/286))

![image](https://github.com/sonic16x/interslavic/assets/56205890/c76d1ca5-d7b1-41ed-944a-7ec6ca45d117)

After:

![image](https://github.com/sonic16x/interslavic/assets/56205890/27b5a766-813d-445f-a078-31c3adf12f68)

Related to: https://github.com/medzuslovjansky/js-utils/pull/39