### PR TITLE
fix: searching words with ȯ/ò/ъ in etymological mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "25.2.0",
         "@ag-grid-community/core": "25.2.0",
-        "@interslavic/utils": "^3.1.8",
+        "@interslavic/utils": "^3.1.9",
         "classnames": "2.3.2",
         "lodash": "4.17.21",
         "md5": "2.3.0",
@@ -2405,9 +2405,9 @@
       "dev": true
     },
     "node_modules/@interslavic/utils": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@interslavic/utils/-/utils-3.1.8.tgz",
-      "integrity": "sha512-02K7YuA7Yrcadu6eHd+ZcFBp2h7w4fTzUxVO/M8wrkBht5F7BM2BmeF33RLeuyVO5mQbO0QuaD7TD+k+mET6rg==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@interslavic/utils/-/utils-3.1.9.tgz",
+      "integrity": "sha512-IrT2H0V37y/6adqqIRqqivIWGgP8lyoL2UJkXl8dlHus7dYU6OQZwA3NZTEEPkRkv2rthbn317IOp3mRR8SXdg==",
       "dependencies": {
         "jest-allure2-reporter": "^2.0.0-beta.14",
         "tslib": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "25.2.0",
     "@ag-grid-community/core": "25.2.0",
-    "@interslavic/utils": "^3.1.8",
+    "@interslavic/utils": "^3.1.9",
     "classnames": "2.3.2",
     "lodash": "4.17.21",
     "md5": "2.3.0",

--- a/src/services/dictionary.ts
+++ b/src/services/dictionary.ts
@@ -357,10 +357,6 @@ class DictionaryClass {
         let isvText = '';
         if (from === 'isv' || twoWaySearch) {
             isvText = inputWord;
-            // Fix for search by character ȯ
-            if (flavorisationType === '2' && this.isvSearchLetters.from.includes('ȯ')) {
-                isvText = isvText.replace(/[ȯòъ]/g, '{ȯ}');
-            }
             isvText = this.applyIsvSearchLetters(getLatin(isvText, flavorisationType, true), flavorisationType);
             isvText = this.inputPrepare('isv-src', isvText);
         }


### PR DESCRIPTION
![image](https://github.com/sonic16x/interslavic/assets/1962469/8006e1b8-3fdd-4e2f-baca-e9c9304a56ab)
