### PR TITLE
feat: ranked sorting by type

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -61,7 +61,6 @@ export const initialFields = [
 ]
 
 export const initialAddFields = [
-    'type',
     'sameInLanguages',
     'genesis',
 ]


### PR DESCRIPTION
* There were some missing libs, so I just had to add them
* `type` is downloaded
* Word sorting takes into account "type" as a secondary criteria when the levenstein distance = 0